### PR TITLE
[PR 3/7] Extract FilterEngine; add typed Error subclasses

### DIFF
--- a/packages/core/src/FilterEngine.ts
+++ b/packages/core/src/FilterEngine.ts
@@ -1,0 +1,208 @@
+import { FilterError } from './errors';
+import type { Dict, Filter, FilterBetween, FilterIn, FilterRaw, FilterSpecial } from './types';
+
+const singleKey = (filter: Dict<any>, op: string): string => {
+  const keys = Object.keys(filter);
+  if (keys.length !== 1) {
+    throw new FilterError(`${op} expects exactly one key, got ${keys.length}`);
+  }
+  return keys[0];
+};
+
+async function propertyFilter(items: Dict<any>[], filter: Dict<any>): Promise<Dict<any>[]> {
+  const counts: { [key: string]: number } = {};
+  // biome-ignore lint/suspicious/noAssignInExpressions: concise counter init
+  items.forEach((item) => (counts[item.id] = 0));
+  for (const key in filter) {
+    items.forEach((item) => {
+      if (item[key] === filter[key]) {
+        counts[item.id] += 1;
+      }
+    });
+  }
+  const filterCount = Object.keys(filter).length;
+  return items.filter((item) => counts[item.id] === filterCount);
+}
+
+async function andFilter(items: Dict<any>[], filters: Filter<Dict<any>>[]): Promise<Dict<any>[]> {
+  const counts: { [key: string]: number } = items.reduce(
+    (obj, item) => {
+      obj[item.id] = 0;
+      return obj;
+    },
+    <{ [key: string]: number }>{},
+  );
+  await Promise.all(
+    filters.map(async (filter) => {
+      const filterItems = await filterList(items, filter);
+      filterItems.forEach((item) => {
+        counts[item.id] += 1;
+      });
+    }),
+  );
+  const filterCount = filters.length;
+  return items.filter((item) => counts[item.id] === filterCount);
+}
+
+async function notFilter(items: Dict<any>[], filter: Filter<Dict<any>>): Promise<Dict<any>[]> {
+  const array = await filterList(items, filter);
+  const exists: { [key: string]: boolean } = {};
+  array.forEach((item) => {
+    exists[item.id] = exists[item.id] || true;
+  });
+  return items.filter((item) => !exists[item.id]);
+}
+
+async function orFilter(items: Dict<any>[], filters: Filter<Dict<any>>[]): Promise<Dict<any>[]> {
+  const arrays = await Promise.all(filters.map(async (filter) => await filterList(items, filter)));
+  const exists: { [key: string]: boolean } = {};
+  arrays.forEach((array) =>
+    array.forEach((item) => {
+      exists[item.id] = exists[item.id] || true;
+    }),
+  );
+  return items.filter((item) => exists[item.id]);
+}
+
+async function inFilter(
+  items: Dict<any>[],
+  filter: Partial<FilterIn<Dict<any>>>,
+): Promise<Dict<any>[]> {
+  const key = singleKey(filter, '$in');
+  return items.filter((item) => {
+    const values = filter[key];
+    if (Array.isArray(values)) {
+      for (const value of values) {
+        if (item[key] === value) return true;
+      }
+    }
+    return false;
+  });
+}
+
+async function notInFilter(
+  items: Dict<any>[],
+  filter: Partial<FilterIn<Dict<any>>>,
+): Promise<Dict<any>[]> {
+  const key = singleKey(filter, '$notIn');
+  return items.filter((item) => {
+    const values = filter[key];
+    if (Array.isArray(values)) {
+      for (const value of values) {
+        if (item[key] === value) return false;
+      }
+    }
+    return true;
+  });
+}
+
+async function nullFilter(items: Dict<any>[], key: string): Promise<Dict<any>[]> {
+  return items.filter((item) => item[key] === null || item[key] === undefined);
+}
+
+async function notNullFilter(items: Dict<any>[], key: string): Promise<Dict<any>[]> {
+  return items.filter((item) => item[key] !== null && item[key] !== undefined);
+}
+
+async function betweenFilter(
+  items: Dict<any>[],
+  filter: Partial<FilterBetween<Dict<any>>>,
+): Promise<Dict<any>[]> {
+  const key = singleKey(filter, '$between');
+  const range = filter[key];
+  if (range === undefined) return items;
+  return items.filter((item) => range.to >= item[key] && item[key] >= range.from);
+}
+
+async function notBetweenFilter(
+  items: Dict<any>[],
+  filter: Partial<FilterBetween<Dict<any>>>,
+): Promise<Dict<any>[]> {
+  const key = singleKey(filter, '$notBetween');
+  const range = filter[key];
+  if (range === undefined) return items;
+  return items.filter((item) => range.to < item[key] || item[key] < range.from);
+}
+
+async function gtFilter(items: Dict<any>[], filter: Partial<Dict<any>>): Promise<Dict<any>[]> {
+  const key = singleKey(filter, '$gt');
+  return items.filter((item) => item[key] > filter[key]);
+}
+
+async function gteFilter(items: Dict<any>[], filter: Partial<Dict<any>>): Promise<Dict<any>[]> {
+  const key = singleKey(filter, '$gte');
+  return items.filter((item) => item[key] >= filter[key]);
+}
+
+async function ltFilter(items: Dict<any>[], filter: Partial<Dict<any>>): Promise<Dict<any>[]> {
+  const key = singleKey(filter, '$lt');
+  return items.filter((item) => item[key] < filter[key]);
+}
+
+async function lteFilter(items: Dict<any>[], filter: Partial<Dict<any>>): Promise<Dict<any>[]> {
+  const key = singleKey(filter, '$lte');
+  return items.filter((item) => item[key] <= filter[key]);
+}
+
+async function rawFilter(items: Dict<any>[], filter: FilterRaw): Promise<Dict<any>[]> {
+  const fn = compileRawQuery(filter.$query);
+  const params = filter.$bindings;
+  if (Array.isArray(params)) {
+    return items.filter((item) => fn(item, ...params));
+  }
+  return items.filter((item) => fn(item, params));
+}
+
+async function asyncFilter(
+  items: Dict<any>[],
+  pending: Promise<Filter<Dict<any>>>,
+): Promise<Dict<any>[]> {
+  const filter = await pending;
+  if (filter && Object.keys(filter).length > 0) {
+    return filterList(items, filter);
+  }
+  return items;
+}
+
+async function specialFilter(
+  items: Dict<any>[],
+  filter: FilterSpecial<Dict<any>>,
+): Promise<Dict<any>[]> {
+  const keys = Object.keys(filter);
+  if (keys.length !== 1) {
+    throw new FilterError(`special filter expects exactly one operator, got ${keys.length}`);
+  }
+  if (filter.$and !== undefined) return andFilter(items, filter.$and);
+  if (filter.$or !== undefined) return orFilter(items, filter.$or);
+  if (filter.$not !== undefined) return notFilter(items, filter.$not);
+  if (filter.$in !== undefined) return inFilter(items, filter.$in);
+  if (filter.$notIn !== undefined) return notInFilter(items, filter.$notIn);
+  if (filter.$null !== undefined) return nullFilter(items, filter.$null as string);
+  if (filter.$notNull !== undefined) return notNullFilter(items, filter.$notNull as string);
+  if (filter.$between !== undefined) return betweenFilter(items, filter.$between);
+  if (filter.$notBetween !== undefined) return notBetweenFilter(items, filter.$notBetween);
+  if (filter.$gt !== undefined) return gtFilter(items, filter.$gt);
+  if (filter.$gte !== undefined) return gteFilter(items, filter.$gte);
+  if (filter.$lt !== undefined) return ltFilter(items, filter.$lt);
+  if (filter.$lte !== undefined) return lteFilter(items, filter.$lte);
+  if (filter.$raw !== undefined) return rawFilter(items, filter.$raw);
+  if (filter.$async !== undefined) return asyncFilter(items, filter.$async);
+  throw new FilterError(`unknown special filter operator: ${keys[0]}`);
+}
+
+function compileRawQuery(source: string): (...args: any[]) => any {
+  // biome-ignore lint/security/noGlobalEval: in-memory filter evaluates raw predicate strings by design
+  return eval(source);
+}
+
+export async function filterList(
+  items: Dict<any>[],
+  filter: Filter<Dict<any>> = {},
+): Promise<Dict<any>[]> {
+  for (const key in filter) {
+    if (key.startsWith('$')) {
+      return specialFilter(items, <FilterSpecial<Dict<any>>>filter);
+    }
+  }
+  return propertyFilter(items, <Partial<Dict<any>>>filter);
+}

--- a/packages/core/src/MemoryConnector.ts
+++ b/packages/core/src/MemoryConnector.ts
@@ -1,12 +1,8 @@
+import { filterList } from './FilterEngine';
 import {
   type BaseType,
   type Connector,
   type Dict,
-  type Filter,
-  type FilterBetween,
-  type FilterIn,
-  type FilterRaw,
-  type FilterSpecial,
   KeyType,
   type Scope,
   SortDirection,
@@ -45,7 +41,7 @@ export class MemoryConnector implements Connector {
     skip,
     order = [],
   }: Scope): Promise<Dict<any>[]> {
-    let items = await this.filter(this.collection(tableName), filter);
+    let items = await filterList(this.collection(tableName), filter);
     if (skip && limit) {
       items = items.slice(skip, skip + limit);
     } else if (skip) {
@@ -86,303 +82,50 @@ export class MemoryConnector implements Connector {
     return items;
   }
 
-  private async propertyFilter(items: Dict<any>[], filter: Dict<any>): Promise<Dict<any>[]> {
-    // Cost: (1, n, m) => O(n,m) = (n) + (n * m) + (m * O(this.filter))
-    const counts: { [key: string]: number } = {};
-    // biome-ignore lint/suspicious/noAssignInExpressions: concise counter init
-    items.forEach((item) => (counts[item.id] = 0));
-    for (const key in filter) {
-      items.forEach((item) => {
-        if (item[key] === filter[key]) {
-          counts[item.id] += 1;
-        }
-      });
-    }
-    const filterCount = Object.keys(filter).length;
-    return items.filter((item) => counts[item.id] === filterCount);
-  }
-
-  private async andFilter(items: Dict<any>[], filters: Filter<Dict<any>>[]): Promise<Dict<any>[]> {
-    // Cost: (1, n, m) => O(n,m) = (n) + (n * m) + (m * O(this.filter))
-    const counts: { [key: string]: number } = items.reduce(
-      (obj, item) => {
-        obj[item.id] = 0;
-        return obj;
-      },
-      <{ [key: string]: number }>{},
-    );
-    await Promise.all(
-      filters.map(async (filter) => {
-        const filterItems = await this.filter(items, filter);
-        filterItems.forEach((item) => {
-          counts[item.id] += 1;
-        });
-      }),
-    );
-    const filterCount = filters.length;
-    return items.filter((item) => counts[item.id] === filterCount);
-  }
-
-  private async notFilter(items: Dict<any>[], filter: Filter<Dict<any>>): Promise<Dict<any>[]> {
-    // Cost: (1, n, 1) => O(n) = 2n + O(this.filter(n))
-    const array: Dict<any>[] = await this.filter(items, filter);
-    const exists: { [key: string]: boolean } = {};
-    array.forEach((item) => {
-      exists[item.id] = exists[item.id] || true;
-    });
-    return await items.filter((item) => !exists[item.id]);
-  }
-
-  private async orFilter(items: Dict<any>[], filters: Filter<Dict<any>>[]): Promise<Dict<any>[]> {
-    // Cost: (1, n, m) => O(n,m) = (n) + (n * m) + (m * O(this.filter(n)))
-    const arrays: Dict<any>[][] = await Promise.all(
-      filters.map(async (filter) => await this.filter(items, filter)),
-    );
-    const exists: { [key: string]: boolean } = {};
-    arrays.forEach((array) =>
-      array.forEach((item) => {
-        exists[item.id] = exists[item.id] || true;
-      }),
-    );
-    return items.filter((item) => exists[item.id]);
-  }
-
-  private async inFilter(
-    items: Dict<any>[],
-    filter: Partial<FilterIn<Dict<any>>>,
-  ): Promise<Dict<any>[]> {
-    // Cost: (1, n, m) => O(n, m) = n * m;
-    if (Object.keys(filter).length !== 1) throw '[TODO] Return proper error';
-    for (const key in filter) {
-      return items.filter((item) => {
-        const values = filter[key];
-        if (Array.isArray(values)) {
-          for (const value of values) {
-            if (item[key] === value) return true;
-          }
-        }
-        return false;
-      });
-    }
-    throw '[TODO] Should not reach error';
-  }
-
-  private async notInFilter(
-    items: Dict<any>[],
-    filter: Partial<FilterIn<Dict<any>>>,
-  ): Promise<Dict<any>[]> {
-    // Cost: (1, n, m) => O(n, m) = n * m;
-    if (Object.keys(filter).length !== 1) throw '[TODO] Return proper error';
-    for (const key in filter) {
-      return items.filter((item) => {
-        const values = filter[key];
-        if (Array.isArray(values)) {
-          for (const value of values) {
-            if (item[key] === value) return false;
-          }
-        }
-        return true;
-      });
-    }
-    throw '[TODO] Should not reach error';
-  }
-
-  private async nullFilter(items: Dict<any>[], key: string): Promise<Dict<any>[]> {
-    // Cost: (1, n, 1) => O(n) = n;
-    return items.filter((item) => item[key] === null || item[key] === undefined);
-  }
-
-  private async notNullFilter(items: Dict<any>[], key: string): Promise<Dict<any>[]> {
-    // Cost: (1, n, 1) => O(n) = n;
-    return items.filter((item) => item[key] !== null && item[key] !== undefined);
-  }
-
-  private async betweenFilter(
-    items: Dict<any>[],
-    filter: Partial<FilterBetween<Dict<any>>>,
-  ): Promise<Dict<any>[]> {
-    // Cost: (1, n, 1) => O(n) = n;
-    if (Object.keys(filter).length !== 1) throw '[TODO] Return proper error';
-    for (const key in filter) {
-      const filterBetween = filter[key];
-      if (filterBetween !== undefined) {
-        return items.filter(
-          (item) => filterBetween.to >= item[key] && item[key] >= filterBetween.from,
-        );
-      }
-    }
-    throw '[TODO] Should not reach error';
-  }
-
-  private async notBetweenFilter(
-    items: Dict<any>[],
-    filter: Partial<FilterBetween<Dict<any>>>,
-  ): Promise<Dict<any>[]> {
-    // Cost: (1, n, 1) => O(n) = n;
-    if (Object.keys(filter).length !== 1) throw '[TODO] Return proper error';
-    for (const key in filter) {
-      const filterBetween = filter[key];
-      if (filterBetween !== undefined) {
-        return items.filter(
-          (item) => filterBetween.to < item[key] || item[key] < filterBetween.from,
-        );
-      }
-    }
-    throw '[TODO] Should not reach error';
-  }
-
-  private async gtFilter(items: Dict<any>[], filter: Partial<Dict<any>>): Promise<Dict<any>[]> {
-    // Cost: (1, n, 1) => O(n) = n;
-    if (Object.keys(filter).length !== 1) throw '[TODO] Return proper error';
-    for (const key in filter) {
-      return items.filter((item) => item[key] > filter[key]);
-    }
-    throw '[TODO] Should not reach error';
-  }
-
-  private async gteFilter(items: Dict<any>[], filter: Partial<Dict<any>>): Promise<Dict<any>[]> {
-    // Cost: (1, n, 1) => O(n) = n;
-    if (Object.keys(filter).length !== 1) throw '[TODO] Return proper error';
-    for (const key in filter) {
-      return items.filter((item) => item[key] >= filter[key]);
-    }
-    throw '[TODO] Should not reach error';
-  }
-
-  private async ltFilter(items: Dict<any>[], filter: Partial<Dict<any>>): Promise<Dict<any>[]> {
-    // Cost: (1, n, 1) => O(n) = n;
-    if (Object.keys(filter).length !== 1) throw '[TODO] Return proper error';
-    for (const key in filter) {
-      return items.filter((item) => item[key] < filter[key]);
-    }
-    throw '[TODO] Should not reach error';
-  }
-
-  private async lteFilter(items: Dict<any>[], filter: Partial<Dict<any>>): Promise<Dict<any>[]> {
-    // Cost: (1, n, 1) => O(n) = n;
-    if (Object.keys(filter).length !== 1) throw '[TODO] Return proper error';
-    for (const key in filter) {
-      return items.filter((item) => item[key] <= filter[key]);
-    }
-    throw '[TODO] Should not reach error';
-  }
-
-  private async rawFilter(items: Dict<any>[], filter: FilterRaw): Promise<Dict<any>[]> {
-    // Cost: (1, n, 1) => O(n) = n;
-    // biome-ignore lint/security/noGlobalEval: MemoryConnector evaluates raw filter predicate strings by design
-    const fn = eval(filter.$query);
-    const params = filter.$bindings;
-    if (Array.isArray(params)) {
-      return items.filter((item) => fn(item, ...params));
-    }
-    return items.filter((item) => fn(item, params));
-  }
-
-  private async asyncFilter(
-    items: Dict<any>[],
-    asyncFilter: Promise<Filter<Dict<any>>>,
-  ): Promise<Dict<any>[]> {
-    const filter = await asyncFilter;
-    if (filter && Object.keys(filter).length > 0) {
-      return this.filter(items, filter);
-    }
-    return items;
-  }
-
-  private async specialFilter(
-    items: Dict<any>[],
-    filter: FilterSpecial<Dict<any>>,
-  ): Promise<Dict<any>[]> {
-    if (Object.keys(filter).length !== 1) throw '[TODO] Return proper error';
-    if (filter.$and !== undefined) return await this.andFilter(items, filter.$and);
-    if (filter.$or !== undefined) return await this.orFilter(items, filter.$or);
-    if (filter.$not !== undefined) return await this.notFilter(items, filter.$not);
-    if (filter.$in !== undefined) return await this.inFilter(items, filter.$in);
-    if (filter.$notIn !== undefined) return await this.notInFilter(items, filter.$notIn);
-    if (filter.$null !== undefined) return await this.nullFilter(items, filter.$null as string);
-    if (filter.$notNull !== undefined)
-      return await this.notNullFilter(items, filter.$notNull as string);
-    if (filter.$between !== undefined) return await this.betweenFilter(items, filter.$between);
-    if (filter.$notBetween !== undefined)
-      return await this.notBetweenFilter(items, filter.$notBetween);
-    if (filter.$gt !== undefined) return await this.gtFilter(items, filter.$gt);
-    if (filter.$gte !== undefined) return await this.gteFilter(items, filter.$gte);
-    if (filter.$lt !== undefined) return await this.ltFilter(items, filter.$lt);
-    if (filter.$lte !== undefined) return await this.lteFilter(items, filter.$lte);
-    if (filter.$raw !== undefined) return await this.rawFilter(items, filter.$raw);
-    if (filter.$async !== undefined) return await this.asyncFilter(items, filter.$async);
-    throw '[TODO] Should not reach error';
-  }
-
-  private async filter(items: Dict<any>[], filter: Filter<Dict<any>> = {}): Promise<Dict<any>[]> {
-    for (const key in filter) {
-      if (key.startsWith('$')) {
-        return await this.specialFilter(items, <FilterSpecial<Dict<any>>>filter);
-      }
-    }
-    return await this.propertyFilter(items, <Partial<Dict<any>>>filter);
-  }
-
   async query(scope: Scope): Promise<Dict<any>[]> {
     const items = await this.items(scope);
     return clone(items);
   }
 
   async count(scope: Scope): Promise<number> {
-    try {
-      const items = await this.items(scope);
-      return items.length;
-    } catch (e) {
-      return Promise.reject(e);
-    }
+    const items = await this.items(scope);
+    return items.length;
   }
 
   async select(scope: Scope, ...keys: string[]): Promise<Dict<any>[]> {
-    try {
-      const items = await this.items(scope);
-      return items.map((item) => {
-        const obj: Dict<any> = {};
-        for (const key of keys) {
-          obj[key] = item[key];
-        }
-        return obj;
-      });
-    } catch (e) {
-      return Promise.reject(e);
-    }
+    const items = await this.items(scope);
+    return items.map((item) => {
+      const obj: Dict<any> = {};
+      for (const key of keys) {
+        obj[key] = item[key];
+      }
+      return obj;
+    });
   }
 
   async updateAll(scope: Scope, attrs: Partial<Dict<any>>): Promise<Dict<any>[]> {
-    try {
-      const items = await this.items(scope);
-      items.forEach((item) => {
-        for (const key in attrs) {
-          item[key] = attrs[key];
-        }
-      });
-      return Promise.resolve(clone(items));
-    } catch (e) {
-      return Promise.reject(e);
-    }
+    const items = await this.items(scope);
+    items.forEach((item) => {
+      for (const key in attrs) {
+        item[key] = attrs[key];
+      }
+    });
+    return clone(items);
   }
 
   async deleteAll(scope: Scope): Promise<Dict<any>[]> {
-    try {
-      const items = await this.items(scope);
-      const result = clone(items);
-      const collection = this.collection(scope.tableName);
-      let index = 0;
-      while (index < collection.length) {
-        if (items.includes(collection[index])) {
-          collection.splice(index, 1);
-        } else {
-          index += 1;
-        }
+    const items = await this.items(scope);
+    const result = clone(items);
+    const collection = this.collection(scope.tableName);
+    let index = 0;
+    while (index < collection.length) {
+      if (items.includes(collection[index])) {
+        collection.splice(index, 1);
+      } else {
+        index += 1;
       }
-      return result;
-    } catch (e) {
-      return Promise.reject(e);
     }
+    return result;
   }
 
   async batchInsert(
@@ -390,38 +133,38 @@ export class MemoryConnector implements Connector {
     keys: Dict<KeyType>,
     items: Dict<any>[],
   ): Promise<Dict<any>[]> {
-    try {
-      const result: Dict<any>[] = [];
-      for (const item of items) {
-        const keyValues: Dict<any> = {};
-        for (const key in keys) {
-          switch (keys[key]) {
-            case KeyType.uuid:
-              keyValues[key] = uuid();
-              break;
-            case KeyType.number:
-              keyValues[key] = this.nextId(tableName);
-              break;
-          }
+    const result: Dict<any>[] = [];
+    for (const item of items) {
+      const keyValues: Dict<any> = {};
+      for (const key in keys) {
+        switch (keys[key]) {
+          case KeyType.uuid:
+            keyValues[key] = uuid();
+            break;
+          case KeyType.number:
+            keyValues[key] = this.nextId(tableName);
+            break;
         }
-        const attributes = { ...item, ...keyValues };
-        this.collection(tableName).push(attributes);
-        result.push(clone(attributes));
       }
-      return Promise.resolve(result);
-    } catch (e) {
-      return Promise.reject(e);
+      const attributes = { ...item, ...keyValues };
+      this.collection(tableName).push(attributes);
+      result.push(clone(attributes));
     }
+    return result;
   }
 
   async execute(query: string, bindings: BaseType | BaseType[]): Promise<any[]> {
-    // biome-ignore lint/security/noGlobalEval: MemoryConnector.execute evaluates raw query strings by design
-    const fn = eval(query);
+    const fn = compileExecute(query);
     if (Array.isArray(bindings)) {
       return fn(this.storage, ...bindings);
     }
     return fn(this.storage, bindings);
   }
+}
+
+function compileExecute(source: string): (...args: any[]) => any[] {
+  // biome-ignore lint/security/noGlobalEval: MemoryConnector.execute evaluates raw query strings by design
+  return eval(source);
 }
 
 export default MemoryConnector;

--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -1,3 +1,4 @@
+import { NotFoundError, PersistenceError } from './errors';
 import {
   type Connector,
   type Dict,
@@ -230,7 +231,7 @@ export class ModelClass {
           this.persistentProps = item;
           this.changedProps = {};
         } else {
-          throw 'Item not found';
+          throw new NotFoundError('Item not found');
         }
       }
     } else {
@@ -247,7 +248,7 @@ export class ModelClass {
         this.persistentProps = item;
         this.changedProps = {};
       } else {
-        throw 'Failed to insert item';
+        throw new PersistenceError('Failed to insert item');
       }
     }
     return this as M;

--- a/packages/core/src/__tests__/MemoryConnector.spec.ts
+++ b/packages/core/src/__tests__/MemoryConnector.spec.ts
@@ -1,5 +1,5 @@
 import { type FilterSpecGroup, context, it, randomInteger } from '.';
-import { type Dict, type Filter, MemoryConnector, type Storage, clone } from '..';
+import { type Dict, type Filter, FilterError, MemoryConnector, type Storage, clone } from '..';
 import { KeyType, type OrderColumn, SortDirection } from '../types';
 
 let storage: Storage = {};
@@ -53,18 +53,18 @@ const filterSpecGroups: FilterSpecGroup = {
     { filter: { $or: [{ id: 2 }, { id: 2 }] }, results: [2] },
   ],
   $in: [
-    { filter: { $in: {} }, results: '[TODO] Return proper error' },
+    { filter: { $in: {} }, results: FilterError },
     { filter: { $in: { id: [validId] } }, results: [validId] },
     { filter: { $in: { id: [2, 3] } }, results: [2, 3] },
     { filter: { $in: { id: [2, 2] } }, results: [2] },
-    { filter: { $in: { id: [1], foo: ['bar'] } }, results: '[TODO] Return proper error' },
+    { filter: { $in: { id: [1], foo: ['bar'] } }, results: FilterError },
   ],
   $notIn: [
-    { filter: { $notIn: {} }, results: '[TODO] Return proper error' },
+    { filter: { $notIn: {} }, results: FilterError },
     { filter: { $notIn: { id: [2] } }, results: [1, 3] },
     { filter: { $notIn: { id: [2, 3] } }, results: [1] },
     { filter: { $notIn: { id: [2, 2] } }, results: [1, 3] },
-    { filter: { $notIn: { id: [1], foo: ['bar'] } }, results: '[TODO] Return proper error' },
+    { filter: { $notIn: { id: [1], foo: ['bar'] } }, results: FilterError },
   ],
   $null: [
     { filter: { $null: 'foo' }, results: [2] },
@@ -77,7 +77,7 @@ const filterSpecGroups: FilterSpecGroup = {
     { filter: { $notNull: 'bar' }, results: [] },
   ],
   $between: [
-    { filter: { $between: {} }, results: '[TODO] Return proper error' },
+    { filter: { $between: {} }, results: FilterError },
     { filter: { $between: { id: { from: 1, to: 2 } } }, results: [1, 2] },
     { filter: { $between: { foo: { from: 'a', to: 'z' } } }, results: [1, 3] },
     { filter: { $between: { id: { from: 0, to: 1 } } }, results: [1] },
@@ -87,11 +87,11 @@ const filterSpecGroups: FilterSpecGroup = {
     { filter: { $between: { id: { from: 3, to: 1 } } }, results: [] },
     {
       filter: { $between: { id: { from: 1, to: 3 }, foo: { from: 'a', to: 'z' } } },
-      results: '[TODO] Return proper error',
+      results: FilterError,
     },
   ],
   $notBetween: [
-    { filter: { $notBetween: {} }, results: '[TODO] Return proper error' },
+    { filter: { $notBetween: {} }, results: FilterError },
     { filter: { $notBetween: { id: { from: 1, to: 2 } } }, results: [3] },
     { filter: { $notBetween: { foo: { from: 'a', to: 'z' } } }, results: [] },
     { filter: { $notBetween: { id: { from: 0, to: 1 } } }, results: [2, 3] },
@@ -104,46 +104,46 @@ const filterSpecGroups: FilterSpecGroup = {
     { filter: { $notBetween: { id: { from: 3, to: 1 } } }, results: [1, 2, 3] },
     {
       filter: { $notBetween: { id: { from: 1, to: 3 }, foo: { from: 'a', to: 'z' } } },
-      results: '[TODO] Return proper error',
+      results: FilterError,
     },
   ],
   $gt: [
-    { filter: { $gt: {} }, results: '[TODO] Return proper error' },
+    { filter: { $gt: {} }, results: FilterError },
     { filter: { $gt: { id: 2 } }, results: [3] },
     { filter: { $gt: { foo: 'bar' } }, results: [] },
     { filter: { $gt: { foo: 'a' } }, results: [1, 3] },
     { filter: { $gt: { id: 0 } }, results: [1, 2, 3] },
     { filter: { $gt: { id: invalidId } }, results: [] },
-    { filter: { $gt: { id: 1, foo: 'a' } }, results: '[TODO] Return proper error' },
+    { filter: { $gt: { id: 1, foo: 'a' } }, results: FilterError },
   ],
   $gte: [
-    { filter: { $gte: {} }, results: '[TODO] Return proper error' },
+    { filter: { $gte: {} }, results: FilterError },
     { filter: { $gte: { id: 2 } }, results: [2, 3] },
     { filter: { $gte: { foo: 'z' } }, results: [] },
     { filter: { $gte: { foo: 'bar' } }, results: [1, 3] },
     { filter: { $gte: { foo: 'a' } }, results: [1, 3] },
     { filter: { $gte: { id: 0 } }, results: [1, 2, 3] },
     { filter: { $gte: { id: invalidId } }, results: [] },
-    { filter: { $gte: { id: 1, foo: 'a' } }, results: '[TODO] Return proper error' },
+    { filter: { $gte: { id: 1, foo: 'a' } }, results: FilterError },
   ],
   $lt: [
-    { filter: { $lt: {} }, results: '[TODO] Return proper error' },
+    { filter: { $lt: {} }, results: FilterError },
     { filter: { $lt: { id: 2 } }, results: [1] },
     { filter: { $lt: { foo: 'bar' } }, results: [] },
     { filter: { $lt: { foo: 'z' } }, results: [1, 3] },
     { filter: { $lt: { id: 4 } }, results: [1, 2, 3] },
     { filter: { $lt: { id: 0 } }, results: [] },
-    { filter: { $lt: { id: 1, foo: 'a' } }, results: '[TODO] Return proper error' },
+    { filter: { $lt: { id: 1, foo: 'a' } }, results: FilterError },
   ],
   $lte: [
-    { filter: { $lte: {} }, results: '[TODO] Return proper error' },
+    { filter: { $lte: {} }, results: FilterError },
     { filter: { $lte: { id: 2 } }, results: [1, 2] },
     { filter: { $lte: { foo: 'a' } }, results: [] },
     { filter: { $lte: { foo: 'bar' } }, results: [1, 3] },
     { filter: { $lte: { foo: 'z' } }, results: [1, 3] },
     { filter: { $lte: { id: 4 } }, results: [1, 2, 3] },
     { filter: { $lte: { id: 0 } }, results: [] },
-    { filter: { $lte: { id: 1, foo: 'a' } }, results: '[TODO] Return proper error' },
+    { filter: { $lte: { id: 1, foo: 'a' } }, results: FilterError },
   ],
 };
 
@@ -337,7 +337,7 @@ describe('Connector', () => {
                     });
                   } else {
                     it('rejects filter and returns error', () => {
-                      return expect(subject()).rejects.toEqual(results);
+                      return expect(subject()).rejects.toBeInstanceOf(results);
                     });
                   }
                 },
@@ -450,7 +450,7 @@ describe('Connector', () => {
                     });
                   } else {
                     it('rejects filter and returns error', () => {
-                      return expect(subject()).rejects.toEqual(results);
+                      return expect(subject()).rejects.toBeInstanceOf(results);
                     });
                   }
                 },
@@ -556,7 +556,7 @@ describe('Connector', () => {
                         });
                       } else {
                         it('rejects filter and returns error', () => {
-                          return expect(subject()).rejects.toEqual(results);
+                          return expect(subject()).rejects.toBeInstanceOf(results);
                         });
                       }
                     },
@@ -664,7 +664,7 @@ describe('Connector', () => {
                         });
                       } else {
                         it('rejects filter and returns error', () => {
-                          return expect(subject()).rejects.toEqual(results);
+                          return expect(subject()).rejects.toBeInstanceOf(results);
                         });
                       }
                     },
@@ -750,7 +750,7 @@ describe('Connector', () => {
                     });
                   } else {
                     it('rejects filter and returns error', () => {
-                      return expect(subject()).rejects.toEqual(results);
+                      return expect(subject()).rejects.toBeInstanceOf(results);
                     });
                   }
                 },
@@ -885,7 +885,7 @@ describe('Connector', () => {
                     });
                   } else {
                     it('rejects filter and returns error', () => {
-                      return expect(subject()).rejects.toEqual(results);
+                      return expect(subject()).rejects.toBeInstanceOf(results);
                     });
                   }
                 },
@@ -1018,7 +1018,7 @@ describe('Connector', () => {
                     });
                   } else {
                     it('rejects filter and returns error', () => {
-                      return expect(subject()).rejects.toEqual(results);
+                      return expect(subject()).rejects.toBeInstanceOf(results);
                     });
                   }
                 },

--- a/packages/core/src/__tests__/types.ts
+++ b/packages/core/src/__tests__/types.ts
@@ -1,4 +1,4 @@
-import type { Filter } from '..';
+import type { Filter, NextModelError } from '..';
 
 export interface Context {
   definitions: () => void;
@@ -8,7 +8,7 @@ export interface Context {
 
 export interface FilterSpecs {
   filter: Filter<any> | undefined;
-  results: number[] | string;
+  results: number[] | (new (...args: any[]) => NextModelError);
 }
 
 export interface FilterSpecGroup {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,10 @@
+export class NextModelError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = new.target.name;
+  }
+}
+
+export class FilterError extends NextModelError {}
+export class NotFoundError extends NextModelError {}
+export class PersistenceError extends NextModelError {}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,5 @@
+export * from './errors';
+export * from './FilterEngine';
 export * from './types';
 export * from './util';
 export * from './MemoryConnector';


### PR DESCRIPTION
## Summary
- Extract the filter-evaluation logic out of `MemoryConnector` into `packages/core/src/FilterEngine.ts` exposing `filterList(items, filter)`. All 14 `*Filter` helpers move; `MemoryConnector` shrinks from 427 → 165 lines and can be shared by other connectors without re-implementation.
- Add `packages/core/src/errors.ts` with `NextModelError`, `FilterError`, `NotFoundError`, `PersistenceError`. Replace 18 `throw '<string>'` usages with typed errors carrying descriptive messages (e.g. ``\`${op} expects exactly one key, got ${n}\`\`\`).
- Drop the now-unnecessary try/catch-rethrow wrappers in the `MemoryConnector` mutating methods (they Promise.rejected sync throws that would already reject via async).
- Update `MemoryConnector.spec` to assert `rejects.toBeInstanceOf(FilterError)` and tighten `FilterSpecs.results` from `number[] | string` to `number[] | (new (...args) => NextModelError)`.

Stacks on PR 2. All 5062 core tests still pass; `pnpm run ci` (lint + typecheck + test) clean locally.

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean across all 3 TS packages
- [x] `pnpm test` — 5062 tests pass (no behavior change, only error identity)
- [ ] CI green on Node 22.x and 24.x