### PR TITLE
[PR 6/7]: Timestamps with opt-out flag

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -21,6 +21,7 @@ export class ModelClass {
   static keys: Dict<KeyType>;
   static connector: Connector;
   static init: (props: any) => Dict<any>;
+  static timestamps = true;
 
   static modelScope() {
     return {
@@ -256,10 +257,14 @@ export class ModelClass {
 
   async save<M extends ModelClass>(this: M) {
     const model = this.constructor as typeof ModelClass;
+    const now = new Date();
 
     if (this.keys) {
       const changedKeys = Object.keys(this.changedProps);
       if (changedKeys.length > 0) {
+        if (model.timestamps) {
+          this.changedProps.updatedAt = now;
+        }
         const items = await model.connector.updateAll(this.itemScope(), this.changedProps);
         const item = items.pop();
         if (item) {
@@ -274,9 +279,12 @@ export class ModelClass {
         }
       }
     } else {
-      const items = await model.connector.batchInsert(model.tableName, model.keys, [
-        { ...this.persistentProps, ...this.changedProps },
-      ]);
+      const insertProps = { ...this.persistentProps, ...this.changedProps };
+      if (model.timestamps) {
+        if (insertProps.createdAt === undefined) insertProps.createdAt = now;
+        if (insertProps.updatedAt === undefined) insertProps.updatedAt = now;
+      }
+      const items = await model.connector.batchInsert(model.tableName, model.keys, [insertProps]);
       const item = items.pop();
       if (item) {
         this.keys = {};
@@ -326,10 +334,12 @@ export function Model<
   >;
   connector?: Connector;
   keys?: Keys;
+  timestamps?: boolean;
 }) {
   const connector = props.connector ? props.connector : new MemoryConnector();
   const order = props.order ? (Array.isArray(props.order) ? props.order : [props.order]) : [];
   const keyDefinitions = props.keys || { id: KeyType.number };
+  const timestamps = props.timestamps ?? true;
 
   return class Model extends ModelClass {
     static tableName = props.tableName;
@@ -340,6 +350,7 @@ export function Model<
     static keys = keyDefinitions;
     static connector = connector;
     static init = props.init as any;
+    static timestamps = timestamps;
 
     static orderBy<M extends typeof ModelClass>(
       this: M,

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -600,6 +600,82 @@ describe('Model', () => {
     });
   });
 
+  describe('timestamps', () => {
+    it('sets createdAt and updatedAt on insert by default', async () => {
+      storage = {};
+      const before = Date.now();
+      const record = await CreateModel().create({ foo: 'bar' });
+      const after = Date.now();
+      const attrs = record.attributes();
+      expect(attrs.createdAt).toBeInstanceOf(Date);
+      expect(attrs.updatedAt).toBeInstanceOf(Date);
+      expect(attrs.createdAt.getTime()).toBeGreaterThanOrEqual(before);
+      expect(attrs.createdAt.getTime()).toBeLessThanOrEqual(after);
+      expect(attrs.updatedAt).toEqual(attrs.createdAt);
+      storage = {};
+    });
+
+    it('updates updatedAt but not createdAt on save after assign', async () => {
+      storage = {};
+      const record = await CreateModel().create({ foo: 'bar' });
+      const created = record.attributes().createdAt;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      record.assign({ foo: 'changed' });
+      await record.save();
+      const attrs = record.attributes();
+      expect(attrs.createdAt).toEqual(created);
+      expect(attrs.updatedAt.getTime()).toBeGreaterThan(created.getTime());
+      storage = {};
+    });
+
+    it('preserves user-supplied createdAt/updatedAt on insert', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const createdAt = new Date('2020-01-01');
+      const updatedAt = new Date('2021-01-01');
+      const record = await Klass.create({ foo: 'bar', createdAt, updatedAt });
+      const attrs = record.attributes();
+      expect(attrs.createdAt).toEqual(createdAt);
+      expect(attrs.updatedAt).toEqual(updatedAt);
+      storage = {};
+    });
+
+    it('does not write timestamps when opted out', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+        timestamps: false,
+      });
+      const record = await Klass.create({ foo: 'bar' });
+      const attrs = record.attributes();
+      expect(attrs.createdAt).toBeUndefined();
+      expect(attrs.updatedAt).toBeUndefined();
+      storage = {};
+    });
+
+    it('does not bump updatedAt when opted out, even on update', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+        timestamps: false,
+      });
+      const record = await Klass.create({ foo: 'bar' });
+      record.assign({ foo: 'changed' });
+      await record.save();
+      const attrs = record.attributes();
+      expect(attrs.updatedAt).toBeUndefined();
+      storage = {};
+    });
+  });
+
   // describe('.order', () => {
   //   let Klass: typeof Model;
   //   let order: Partial<Order<any>>[] = Faker.order;

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -11,5 +11,5 @@ export function uuid() {
 }
 
 export function clone<T extends object>(obj: T) {
-  return JSON.parse(JSON.stringify(obj)) as T;
+  return structuredClone(obj);
 }


### PR DESCRIPTION
## Summary
- `save()` populates `createdAt` / `updatedAt` on insert and bumps `updatedAt` on update.
- Default-on, Rails-style; user-supplied values on insert are preserved (only fills when undefined).
- Opt-out per model: `Model({ ..., timestamps: false })` or `static timestamps = false` on a subclass.
- Swaps `util.clone()` from `JSON.parse(JSON.stringify())` to `structuredClone()` so MemoryConnector preserves `Date` types (and `Map`/`Set`/etc.) across insert.

Stacked on top of PR 5. Review that one first.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 5096 passed (5 new tests: default behavior, update path, user-supplied preservation, opt-out insert, opt-out update)
- [x] `pnpm run ci` green locally