### PR TITLE
PR 7: Validators + isValid + ValidationError

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -1,4 +1,4 @@
-import { NotFoundError, PersistenceError } from './errors';
+import { NotFoundError, PersistenceError, ValidationError } from './errors';
 import {
   type Connector,
   type Dict,
@@ -8,6 +8,7 @@ import {
   type OrderColumn,
   type Schema,
   type Scope,
+  type Validator,
 } from './types';
 
 import { MemoryConnector } from './MemoryConnector';
@@ -22,6 +23,7 @@ export class ModelClass {
   static connector: Connector;
   static init: (props: any) => Dict<any>;
   static timestamps = true;
+  static validators: Validator<any>[] = [];
 
   static modelScope() {
     return {
@@ -255,8 +257,19 @@ export class ModelClass {
     };
   }
 
+  async isValid(): Promise<boolean> {
+    const model = this.constructor as typeof ModelClass;
+    for (const validator of model.validators) {
+      if (!(await validator(this))) return false;
+    }
+    return true;
+  }
+
   async save<M extends ModelClass>(this: M) {
     const model = this.constructor as typeof ModelClass;
+    if (!(await this.isValid())) {
+      throw new ValidationError('Validation failed');
+    }
     const now = new Date();
 
     if (this.keys) {
@@ -335,11 +348,15 @@ export function Model<
   connector?: Connector;
   keys?: Keys;
   timestamps?: boolean;
+  validators?: Validator<
+    PersistentProps & { [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }
+  >[];
 }) {
   const connector = props.connector ? props.connector : new MemoryConnector();
   const order = props.order ? (Array.isArray(props.order) ? props.order : [props.order]) : [];
   const keyDefinitions = props.keys || { id: KeyType.number };
   const timestamps = props.timestamps ?? true;
+  const validators = props.validators || [];
 
   return class Model extends ModelClass {
     static tableName = props.tableName;
@@ -351,6 +368,7 @@ export function Model<
     static connector = connector;
     static init = props.init as any;
     static timestamps = timestamps;
+    static validators = validators as Validator<any>[];
 
     static orderBy<M extends typeof ModelClass>(
       this: M,

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -676,6 +676,104 @@ describe('Model', () => {
     });
   });
 
+  describe('validators', () => {
+    it('isValid() returns true when no validators are defined', async () => {
+      storage = {};
+      const record = CreateModel().build({});
+      expect(await record.isValid()).toBe(true);
+      storage = {};
+    });
+
+    it('isValid() returns true when all validators pass', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+        validators: [(instance: any) => instance.foo === 'bar'],
+      });
+      const record = Klass.build({ foo: 'bar' });
+      expect(await record.isValid()).toBe(true);
+      storage = {};
+    });
+
+    it('isValid() returns false when any validator fails', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+        validators: [
+          (instance: any) => instance.foo === 'bar',
+          (instance: any) => instance.bar === 'baz',
+        ],
+      });
+      const record = Klass.build({ foo: 'bar', bar: 'wrong' });
+      expect(await record.isValid()).toBe(false);
+      storage = {};
+    });
+
+    it('supports async validators', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+        validators: [async (instance: any) => instance.foo === 'bar'],
+      });
+      const record = Klass.build({ foo: 'bar' });
+      expect(await record.isValid()).toBe(true);
+      storage = {};
+    });
+
+    it('save() throws ValidationError when invalid', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+        validators: [() => false],
+      });
+      const record = Klass.build({ foo: 'bar' });
+      await expect(record.save()).rejects.toBeInstanceOf(Error);
+      expect(Object.keys(storage[tableName] ?? {})).toHaveLength(0);
+      storage = {};
+    });
+
+    it('save() proceeds when valid', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+        validators: [(instance: any) => instance.foo === 'bar'],
+      });
+      const record = await Klass.create({ foo: 'bar' });
+      expect(record.isPersistent()).toBe(true);
+      storage = {};
+    });
+
+    it('short-circuits on the first failing validator', async () => {
+      storage = {};
+      let secondCalled = false;
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+        validators: [
+          () => false,
+          () => {
+            secondCalled = true;
+            return true;
+          },
+        ],
+      });
+      expect(await Klass.build({}).isValid()).toBe(false);
+      expect(secondCalled).toBe(false);
+      storage = {};
+    });
+  });
+
   // describe('.order', () => {
   //   let Klass: typeof Model;
   //   let order: Partial<Order<any>>[] = Faker.order;

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -8,3 +8,4 @@ export class NextModelError extends Error {
 export class FilterError extends NextModelError {}
 export class NotFoundError extends NextModelError {}
 export class PersistenceError extends NextModelError {}
+export class ValidationError extends NextModelError {}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -92,3 +92,5 @@ export interface Scope {
   skip?: number;
   order?: OrderColumn<any>[];
 }
+
+export type Validator<T> = (instance: T) => boolean | Promise<boolean>;


### PR DESCRIPTION
## Summary
- Adds `Validator<T> = (instance: T) => boolean | Promise<boolean>` type.
- `Model({ ..., validators: [...] })` registers validators on the class.
- Instance `isValid()` runs them in order, short-circuits on first failure.
- `save()` throws `ValidationError` (new, extends `NextModelError`) if `isValid()` is false — no partial writes.

Stacked on top of PR 6. Review that one first.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 5103 passed (7 new tests: empty validators, all pass, any fail, async validator, save-throws-on-invalid, save-proceeds-on-valid, short-circuit)
- [x] `pnpm run ci` green locally