### PR TITLE
PR 8: Lifecycle callbacks

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -1,5 +1,7 @@
 import { NotFoundError, PersistenceError, ValidationError } from './errors';
 import {
+  type Callback,
+  type Callbacks,
   type Connector,
   type Dict,
   type Filter,
@@ -24,6 +26,7 @@ export class ModelClass {
   static init: (props: any) => Dict<any>;
   static timestamps = true;
   static validators: Validator<any>[] = [];
+  static callbacks: Callbacks<any> = {};
 
   static modelScope() {
     return {
@@ -265,12 +268,25 @@ export class ModelClass {
     return true;
   }
 
+  async runCallbacks(kind: keyof Callbacks<any>): Promise<void> {
+    const model = this.constructor as typeof ModelClass;
+    const callbacks = model.callbacks[kind] as Callback<any>[] | undefined;
+    if (!callbacks) return;
+    for (const callback of callbacks) {
+      await callback(this);
+    }
+  }
+
   async save<M extends ModelClass>(this: M) {
     const model = this.constructor as typeof ModelClass;
     if (!(await this.isValid())) {
       throw new ValidationError('Validation failed');
     }
     const now = new Date();
+    const isInsert = !this.keys;
+
+    await this.runCallbacks('beforeSave');
+    await this.runCallbacks(isInsert ? 'beforeCreate' : 'beforeUpdate');
 
     if (this.keys) {
       const changedKeys = Object.keys(this.changedProps);
@@ -311,6 +327,10 @@ export class ModelClass {
         throw new PersistenceError('Failed to insert item');
       }
     }
+
+    await this.runCallbacks(isInsert ? 'afterCreate' : 'afterUpdate');
+    await this.runCallbacks('afterSave');
+
     return this as M;
   }
 
@@ -319,6 +339,7 @@ export class ModelClass {
       throw new PersistenceError('Cannot delete a record that has not been saved');
     }
     const model = this.constructor as typeof ModelClass;
+    await this.runCallbacks('beforeDelete');
     const items = await model.connector.deleteAll(this.itemScope());
     if (items.length === 0) {
       throw new NotFoundError('Item not found');
@@ -326,6 +347,7 @@ export class ModelClass {
     this.persistentProps = { ...this.persistentProps, ...this.changedProps, ...this.keys };
     this.changedProps = {};
     this.keys = undefined;
+    await this.runCallbacks('afterDelete');
     return this as M;
   }
 }
@@ -351,12 +373,16 @@ export function Model<
   validators?: Validator<
     PersistentProps & { [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }
   >[];
+  callbacks?: Callbacks<
+    PersistentProps & { [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }
+  >;
 }) {
   const connector = props.connector ? props.connector : new MemoryConnector();
   const order = props.order ? (Array.isArray(props.order) ? props.order : [props.order]) : [];
   const keyDefinitions = props.keys || { id: KeyType.number };
   const timestamps = props.timestamps ?? true;
   const validators = props.validators || [];
+  const callbacks = props.callbacks || {};
 
   return class Model extends ModelClass {
     static tableName = props.tableName;
@@ -369,6 +395,7 @@ export function Model<
     static init = props.init as any;
     static timestamps = timestamps;
     static validators = validators as Validator<any>[];
+    static callbacks = callbacks as Callbacks<any>;
 
     static orderBy<M extends typeof ModelClass>(
       this: M,

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -774,6 +774,131 @@ describe('Model', () => {
     });
   });
 
+  describe('callbacks', () => {
+    it('runs beforeSave, beforeCreate, afterCreate, afterSave on insert in order', async () => {
+      storage = {};
+      const order: string[] = [];
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+        callbacks: {
+          beforeSave: [() => void order.push('beforeSave')],
+          beforeCreate: [() => void order.push('beforeCreate')],
+          beforeUpdate: [() => void order.push('beforeUpdate')],
+          afterUpdate: [() => void order.push('afterUpdate')],
+          afterCreate: [() => void order.push('afterCreate')],
+          afterSave: [() => void order.push('afterSave')],
+        },
+      });
+      await Klass.create({ foo: 'bar' });
+      expect(order).toEqual(['beforeSave', 'beforeCreate', 'afterCreate', 'afterSave']);
+      storage = {};
+    });
+
+    it('runs beforeSave, beforeUpdate, afterUpdate, afterSave on update in order', async () => {
+      storage = {};
+      const order: string[] = [];
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+        callbacks: {
+          beforeSave: [() => void order.push('beforeSave')],
+          beforeCreate: [() => void order.push('beforeCreate')],
+          beforeUpdate: [() => void order.push('beforeUpdate')],
+          afterUpdate: [() => void order.push('afterUpdate')],
+          afterCreate: [() => void order.push('afterCreate')],
+          afterSave: [() => void order.push('afterSave')],
+        },
+      });
+      const record = await Klass.create({ foo: 'bar' });
+      order.length = 0;
+      record.assign({ foo: 'changed' });
+      await record.save();
+      expect(order).toEqual(['beforeSave', 'beforeUpdate', 'afterUpdate', 'afterSave']);
+      storage = {};
+    });
+
+    it('runs beforeDelete then afterDelete around delete()', async () => {
+      storage = {};
+      const order: string[] = [];
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+        callbacks: {
+          beforeDelete: [() => void order.push('beforeDelete')],
+          afterDelete: [() => void order.push('afterDelete')],
+        },
+      });
+      const record = await Klass.create({ foo: 'bar' });
+      await record.delete();
+      expect(order).toEqual(['beforeDelete', 'afterDelete']);
+      storage = {};
+    });
+
+    it('awaits async callbacks', async () => {
+      storage = {};
+      const order: string[] = [];
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+        callbacks: {
+          beforeSave: [
+            async () => {
+              await new Promise((resolve) => setTimeout(resolve, 5));
+              order.push('beforeSave');
+            },
+          ],
+          afterSave: [() => void order.push('afterSave')],
+        },
+      });
+      await Klass.create({ foo: 'bar' });
+      expect(order).toEqual(['beforeSave', 'afterSave']);
+      storage = {};
+    });
+
+    it('aborts save when a before-callback throws', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+        callbacks: {
+          beforeCreate: [
+            () => {
+              throw new Error('nope');
+            },
+          ],
+        },
+      });
+      await expect(Klass.create({ foo: 'bar' })).rejects.toBeInstanceOf(Error);
+      expect(Object.keys(storage[tableName] ?? {})).toHaveLength(0);
+      storage = {};
+    });
+
+    it('skips callbacks when no changes trigger a save()', async () => {
+      storage = {};
+      let calls = 0;
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+        callbacks: {
+          beforeSave: [() => void calls++],
+          afterSave: [() => void calls++],
+        },
+      });
+      const record = await Klass.create({ foo: 'bar' });
+      calls = 0;
+      await record.save();
+      expect(calls).toBe(2);
+      storage = {};
+    });
+  });
+
   // describe('.order', () => {
   //   let Klass: typeof Model;
   //   let order: Partial<Order<any>>[] = Faker.order;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -94,3 +94,16 @@ export interface Scope {
 }
 
 export type Validator<T> = (instance: T) => boolean | Promise<boolean>;
+
+export type Callback<T> = (instance: T) => void | Promise<void>;
+
+export interface Callbacks<T> {
+  beforeSave?: Callback<T>[];
+  afterSave?: Callback<T>[];
+  beforeCreate?: Callback<T>[];
+  afterCreate?: Callback<T>[];
+  beforeUpdate?: Callback<T>[];
+  afterUpdate?: Callback<T>[];
+  beforeDelete?: Callback<T>[];
+  afterDelete?: Callback<T>[];
+}


### PR DESCRIPTION
## Summary
- New `Callback<T>` / `Callbacks<T>` types with eight slots: `beforeSave`/`afterSave`, `beforeCreate`/`afterCreate`, `beforeUpdate`/`afterUpdate`, `beforeDelete`/`afterDelete`.
- `save()` invokes `beforeSave` → `beforeCreate`|`beforeUpdate` → [write] → `afterCreate`|`afterUpdate` → `afterSave`.
- `delete()` invokes `beforeDelete` → [delete] → `afterDelete`.
- Callbacks awaited in registration order; throwing from a before-callback aborts the operation (no partial write).
- Declared per model via `Model({ ..., callbacks: { ... } })`.

Stacked on top of PR 7. Review that one first.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 5109 passed (6 new tests: insert order, update order, delete order, async, throw aborts, non-changing save still fires save callbacks)
- [x] `pnpm run ci` green locally