### PR TITLE
PR 10: Associations — belongsTo / hasMany / hasOne

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -14,6 +14,12 @@ import {
 } from './types';
 
 import { MemoryConnector } from './MemoryConnector';
+import { singularize } from './util';
+
+export type AssociationOptions = {
+  foreignKey?: string;
+  primaryKey?: string;
+};
 
 export class ModelClass {
   static tableName: string;
@@ -262,6 +268,47 @@ export class ModelClass {
       skip: 0,
       order: [],
     };
+  }
+
+  belongsTo<Related extends typeof ModelClass>(
+    this: ModelClass,
+    Related: Related,
+    options: AssociationOptions = {},
+  ): Promise<InstanceType<Related> | undefined> {
+    const fk = options.foreignKey ?? `${singularize(Related.tableName)}Id`;
+    const pk = options.primaryKey ?? Object.keys(Related.keys)[0] ?? 'id';
+    const fkValue = (this.attributes() as Dict<any>)[fk];
+    if (fkValue === undefined || fkValue === null) {
+      return Promise.resolve(undefined);
+    }
+    return Related.findBy({ [pk]: fkValue }) as Promise<InstanceType<Related> | undefined>;
+  }
+
+  hasMany<Related extends typeof ModelClass>(
+    this: ModelClass,
+    Related: Related,
+    options: AssociationOptions = {},
+  ): Related {
+    const selfModel = this.constructor as typeof ModelClass;
+    const fk = options.foreignKey ?? `${singularize(selfModel.tableName)}Id`;
+    const pk = options.primaryKey ?? Object.keys(selfModel.keys)[0] ?? 'id';
+    const pkValue = (this as any)[pk];
+    return Related.filterBy({ [fk]: pkValue }) as Related;
+  }
+
+  hasOne<Related extends typeof ModelClass>(
+    this: ModelClass,
+    Related: Related,
+    options: AssociationOptions = {},
+  ): Promise<InstanceType<Related> | undefined> {
+    const selfModel = this.constructor as typeof ModelClass;
+    const fk = options.foreignKey ?? `${singularize(selfModel.tableName)}Id`;
+    const pk = options.primaryKey ?? Object.keys(selfModel.keys)[0] ?? 'id';
+    const pkValue = (this as any)[pk];
+    if (pkValue === undefined || pkValue === null) {
+      return Promise.resolve(undefined);
+    }
+    return Related.findBy({ [fk]: pkValue }) as Promise<InstanceType<Related> | undefined>;
   }
 
   async isValid(): Promise<boolean> {

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -977,6 +977,211 @@ describe('Model', () => {
     });
   });
 
+  describe('associations', () => {
+    let assocStorage: Storage = {};
+    const assocConnector = () => new MemoryConnector({ storage: assocStorage });
+
+    beforeEach(() => {
+      assocStorage = {};
+    });
+
+    describe('#belongsTo', () => {
+      it('returns the referenced record using tableName convention', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { userId: number; title: string }) => props,
+          connector: assocConnector(),
+        });
+        const user = await UserKlass.create({ name: 'Alice' });
+        const post = await PostKlass.create({ userId: user.id, title: 'Hello' });
+        const author = await post.belongsTo(UserKlass);
+        expect(author?.attributes().name).toBe('Alice');
+      });
+
+      it('returns undefined when the foreign key is null', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { userId: number | null; title: string }) => props,
+          connector: assocConnector(),
+        });
+        const post = await PostKlass.create({ userId: null, title: 'Orphan' });
+        const author = await post.belongsTo(UserKlass);
+        expect(author).toBeUndefined();
+      });
+
+      it('returns undefined when the referenced record does not exist', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { userId: number; title: string }) => props,
+          connector: assocConnector(),
+        });
+        const post = await PostKlass.create({ userId: 999, title: 'Dangling' });
+        const author = await post.belongsTo(UserKlass);
+        expect(author).toBeUndefined();
+      });
+
+      it('accepts an explicit foreignKey', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { authorId: number; title: string }) => props,
+          connector: assocConnector(),
+        });
+        const user = await UserKlass.create({ name: 'Alice' });
+        const post = await PostKlass.create({ authorId: user.id, title: 'Hello' });
+        const author = await post.belongsTo(UserKlass, { foreignKey: 'authorId' });
+        expect(author?.attributes().name).toBe('Alice');
+      });
+    });
+
+    describe('#hasMany', () => {
+      it('returns a scoped query of related records', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { userId: number; title: string }) => props,
+          connector: assocConnector(),
+        });
+        const user = await UserKlass.create({ name: 'Alice' });
+        const other = await UserKlass.create({ name: 'Bob' });
+        await PostKlass.create({ userId: user.id, title: 'A' });
+        await PostKlass.create({ userId: user.id, title: 'B' });
+        await PostKlass.create({ userId: other.id, title: 'C' });
+        const userPosts = await user.hasMany(PostKlass).all();
+        expect(userPosts).toHaveLength(2);
+        expect(userPosts.map((p) => p.attributes().title).sort()).toEqual(['A', 'B']);
+      });
+
+      it('supports count on the scoped query', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { userId: number; title: string }) => props,
+          connector: assocConnector(),
+        });
+        const user = await UserKlass.create({ name: 'Alice' });
+        await PostKlass.create({ userId: user.id, title: 'A' });
+        await PostKlass.create({ userId: user.id, title: 'B' });
+        expect(await user.hasMany(PostKlass).count()).toBe(2);
+      });
+
+      it('supports further chained scopes on the returned class', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { userId: number; title: string; published: boolean }) => props,
+          connector: assocConnector(),
+        });
+        const user = await UserKlass.create({ name: 'Alice' });
+        await PostKlass.create({ userId: user.id, title: 'A', published: true });
+        await PostKlass.create({ userId: user.id, title: 'B', published: false });
+        const published = await user.hasMany(PostKlass).filterBy({ published: true }).all();
+        expect(published).toHaveLength(1);
+        expect(published[0].attributes().title).toBe('A');
+      });
+
+      it('accepts an explicit foreignKey', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { authorId: number; title: string }) => props,
+          connector: assocConnector(),
+        });
+        const user = await UserKlass.create({ name: 'Alice' });
+        await PostKlass.create({ authorId: user.id, title: 'A' });
+        const posts = await user.hasMany(PostKlass, { foreignKey: 'authorId' }).all();
+        expect(posts).toHaveLength(1);
+      });
+    });
+
+    describe('#hasOne', () => {
+      it('returns the associated record', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const ProfileKlass = Model({
+          tableName: 'profiles',
+          init: (props: { userId: number; bio: string }) => props,
+          connector: assocConnector(),
+        });
+        const user = await UserKlass.create({ name: 'Alice' });
+        await ProfileKlass.create({ userId: user.id, bio: 'hello' });
+        const profile = await user.hasOne(ProfileKlass);
+        expect(profile?.attributes().bio).toBe('hello');
+      });
+
+      it('returns undefined when no related record exists', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const ProfileKlass = Model({
+          tableName: 'profiles',
+          init: (props: { userId: number; bio: string }) => props,
+          connector: assocConnector(),
+        });
+        const user = await UserKlass.create({ name: 'Alice' });
+        const profile = await user.hasOne(ProfileKlass);
+        expect(profile).toBeUndefined();
+      });
+
+      it('accepts an explicit foreignKey', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const ProfileKlass = Model({
+          tableName: 'profiles',
+          init: (props: { ownerId: number; bio: string }) => props,
+          connector: assocConnector(),
+        });
+        const user = await UserKlass.create({ name: 'Alice' });
+        await ProfileKlass.create({ ownerId: user.id, bio: 'hi' });
+        const profile = await user.hasOne(ProfileKlass, { foreignKey: 'ownerId' });
+        expect(profile?.attributes().bio).toBe('hi');
+      });
+    });
+  });
+
   // describe('.order', () => {
   //   let Klass: typeof Model;
   //   let order: Partial<Order<any>>[] = Faker.order;

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -13,3 +13,12 @@ export function uuid() {
 export function clone<T extends object>(obj: T) {
   return structuredClone(obj);
 }
+
+export function singularize(word: string): string {
+  if (word.endsWith('ies') && word.length > 3) return `${word.slice(0, -3)}y`;
+  if (word.endsWith('sses') || word.endsWith('shes') || word.endsWith('ches')) {
+    return word.slice(0, -2);
+  }
+  if (word.endsWith('s') && !word.endsWith('ss')) return word.slice(0, -1);
+  return word;
+}


### PR DESCRIPTION
## Summary
- Add `belongsTo`, `hasMany`, `hasOne` instance methods on `ModelClass`.
- FK convention derived from singularized tableName (`users` → `userId`, `categories` → `categoryId`), with explicit `foreignKey`/`primaryKey` overrides via options.
- `hasMany` returns a scoped subclass, so consumers can chain `.filterBy(...)`, `.count()`, `.all()`, etc.
- `belongsTo`/`hasOne` return `Promise<Instance | undefined>`; gracefully handle null/missing FKs.
- Export `AssociationOptions` type and `singularize` util for reuse.

## Test plan
- [x] `belongsTo` resolves by tableName convention, explicit FK, and returns `undefined` for null/missing records
- [x] `hasMany` returns a scoped class that supports `.all()`, `.count()`, further `.filterBy()`, and explicit FK
- [x] `hasOne` returns the single matching record, `undefined` when absent, and honors explicit FK

Stacked on #51 (PR 9).