### PR TITLE
PR 11: Instance API completeness (update, reload, touch, updateAll)

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -177,6 +177,14 @@ export class ModelClass {
     return await this.connector.deleteAll(this.modelScope());
   }
 
+  static async updateAll<M extends typeof ModelClass>(this: M, attrs: Dict<any>) {
+    const effectiveAttrs = { ...attrs };
+    if (this.timestamps && effectiveAttrs.updatedAt === undefined) {
+      effectiveAttrs.updatedAt = new Date();
+    }
+    return await this.connector.updateAll(this.modelScope(), effectiveAttrs);
+  }
+
   static async findBy<M extends typeof ModelClass>(this: M, filter: Filter<any>) {
     return await this.filterBy(filter).first<M>();
   }
@@ -385,6 +393,40 @@ export class ModelClass {
     return this as M;
   }
 
+  async update<M extends ModelClass>(this: M, attrs: Dict<any>) {
+    this.assign(attrs);
+    return this.save();
+  }
+
+  async touch<M extends ModelClass>(this: M) {
+    if (!this.keys) {
+      throw new PersistenceError('Cannot touch a record that has not been saved');
+    }
+    const model = this.constructor as typeof ModelClass;
+    const now = new Date();
+    const items = await model.connector.updateAll(this.itemScope(), { updatedAt: now });
+    const item = items.pop();
+    if (!item) throw new NotFoundError('Item not found');
+    for (const key in model.keys) delete item[key];
+    this.persistentProps = item;
+    this.changedProps = {};
+    return this as M;
+  }
+
+  async reload<M extends ModelClass>(this: M) {
+    if (!this.keys) {
+      throw new PersistenceError('Cannot reload a record that has not been saved');
+    }
+    const model = this.constructor as typeof ModelClass;
+    const items = await model.connector.query(this.itemScope());
+    const item = items.pop();
+    if (!item) throw new NotFoundError('Item not found');
+    for (const key in model.keys) delete item[key];
+    this.persistentProps = item;
+    this.changedProps = {};
+    return this as M;
+  }
+
   async delete<M extends ModelClass>(this: M) {
     if (!this.keys) {
       throw new PersistenceError('Cannot delete a record that has not been saved');
@@ -516,6 +558,12 @@ export function Model<
       })[];
     }
 
+    static async updateAll<M extends typeof ModelClass>(this: M, attrs: Partial<PersistentProps>) {
+      return (await super.updateAll(attrs)) as (PersistentProps & {
+        [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number;
+      })[];
+    }
+
     static async findBy<M extends typeof ModelClass>(
       this: M,
       filter: Filter<
@@ -597,6 +645,10 @@ export function Model<
 
     revertChange<M extends ModelClass>(this: M, key: keyof PersistentProps): M {
       return super.revertChange(key as string) as M;
+    }
+
+    update<M extends ModelClass>(this: M, attrs: Partial<PersistentProps>): Promise<M> {
+      return super.update(attrs as Dict<any>) as Promise<M>;
     }
   };
 }

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -977,6 +977,134 @@ describe('Model', () => {
     });
   });
 
+  describe('#update', () => {
+    it('assigns and saves in one call', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const record = await Klass.create({ foo: 'a' });
+      const updated = await record.update({ foo: 'b' });
+      expect(updated.attributes().foo).toBe('b');
+      const reloaded = await Klass.findBy({ id: record.attributes().id });
+      expect(reloaded?.attributes().foo).toBe('b');
+      storage = {};
+    });
+  });
+
+  describe('#reload', () => {
+    it('replaces in-memory changes with persisted attributes', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const record = await Klass.create({ foo: 'original' });
+      record.assign({ foo: 'dirty' });
+      expect(record.isChanged()).toBe(true);
+      await record.reload();
+      expect(record.isChanged()).toBe(false);
+      expect(record.attributes().foo).toBe('original');
+      storage = {};
+    });
+
+    it('picks up changes made through other instances', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const a = await Klass.create({ foo: 'a' });
+      const b = (await Klass.findBy({ id: a.attributes().id }))!;
+      await a.update({ foo: 'changed' });
+      await b.reload();
+      expect(b.attributes().foo).toBe('changed');
+      storage = {};
+    });
+
+    it('throws when the record is unsaved', async () => {
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const record = Klass.build({ foo: 'x' });
+      await expect(record.reload()).rejects.toThrow(
+        'Cannot reload a record that has not been saved',
+      );
+    });
+  });
+
+  describe('#touch', () => {
+    it('bumps updatedAt without other changes', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const record = await Klass.create({ foo: 'a' });
+      const originalUpdatedAt = record.attributes().updatedAt as Date;
+      await new Promise((r) => setTimeout(r, 5));
+      await record.touch();
+      const newUpdatedAt = record.attributes().updatedAt as Date;
+      expect(newUpdatedAt.getTime()).toBeGreaterThan(originalUpdatedAt.getTime());
+      expect(record.attributes().foo).toBe('a');
+      storage = {};
+    });
+
+    it('throws when the record is unsaved', async () => {
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const record = Klass.build({ foo: 'x' });
+      await expect(record.touch()).rejects.toThrow('Cannot touch a record that has not been saved');
+    });
+  });
+
+  describe('.updateAll', () => {
+    it('updates all records in scope', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      await Klass.create({ foo: 'a', group: 1 });
+      await Klass.create({ foo: 'b', group: 1 });
+      await Klass.create({ foo: 'c', group: 2 });
+      await Klass.filterBy({ group: 1 }).updateAll({ foo: 'updated' });
+      expect(await Klass.filterBy({ foo: 'updated' }).count()).toBe(2);
+      expect(await Klass.filterBy({ foo: 'c' }).count()).toBe(1);
+      storage = {};
+    });
+
+    it('auto-sets updatedAt when timestamps enabled', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      await Klass.create({ foo: 'a' });
+      await new Promise((r) => setTimeout(r, 5));
+      const before = Date.now();
+      await Klass.updateAll({ foo: 'b' });
+      const after = Date.now();
+      const row = (await Klass.first())!;
+      const updatedAt = row.attributes().updatedAt as Date;
+      expect(updatedAt.getTime()).toBeGreaterThanOrEqual(before);
+      expect(updatedAt.getTime()).toBeLessThanOrEqual(after);
+      storage = {};
+    });
+  });
+
   describe('associations', () => {
     let assocStorage: Storage = {};
     const assocConnector = () => new MemoryConnector({ storage: assocStorage });


### PR DESCRIPTION
## Summary
- `update(attrs)` — assign + save shortcut for single-record updates.
- `reload()` — refresh persistent attrs from storage, clearing any in-flight `changedProps`.
- `touch()` — bump `updatedAt` without mutating other fields (no-op with `timestamps: false` connectors).
- `Model.updateAll(attrs)` — apply attrs across the current scope; auto-sets `updatedAt` when `timestamps` is on.

## Test plan
- [x] `update` writes to storage and returns the typed instance
- [x] `reload` replaces dirty changes with persisted attrs
- [x] `reload` picks up external writes from other instances
- [x] `reload`/`touch` throw when record is unsaved
- [x] `touch` advances `updatedAt`
- [x] `updateAll` updates all scoped rows and auto-sets `updatedAt`

Stacked on #52 (PR 10).