### PR TITLE
PR 12: Query sugar (find, findOrFail, firstOrCreate, updateOrCreate, findOrBuild)

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -194,6 +194,53 @@ export class ModelClass {
     return (await scoped.count()) > 0;
   }
 
+  static async find<M extends typeof ModelClass>(this: M, id: number | string) {
+    const primaryKey = Object.keys(this.keys)[0] ?? 'id';
+    const record = await this.findBy<M>({ [primaryKey]: id });
+    if (!record) {
+      throw new NotFoundError(`${this.name || 'Record'} with ${primaryKey}=${id} not found`);
+    }
+    return record;
+  }
+
+  static async findOrFail<M extends typeof ModelClass>(this: M, filter: Filter<any>) {
+    const record = await this.findBy<M>(filter);
+    if (!record) throw new NotFoundError('Record not found');
+    return record;
+  }
+
+  static async findOrBuild<M extends typeof ModelClass>(
+    this: M,
+    filter: Filter<any>,
+    createProps: any,
+  ) {
+    const record = await this.findBy<M>(filter);
+    if (record) return record;
+    return this.build<M>({ ...filter, ...createProps });
+  }
+
+  static async firstOrCreate<M extends typeof ModelClass>(
+    this: M,
+    filter: Filter<any>,
+    createProps: any = {},
+  ) {
+    const record = await this.findBy<M>(filter);
+    if (record) return record;
+    return this.create<M>({ ...filter, ...createProps });
+  }
+
+  static async updateOrCreate<M extends typeof ModelClass>(
+    this: M,
+    filter: Filter<any>,
+    attrs: Dict<any>,
+  ) {
+    const record = await this.findBy<M>(filter);
+    if (record) {
+      return (record as any).update(attrs) as Promise<InstanceType<M>>;
+    }
+    return this.create<M>({ ...filter, ...attrs });
+  }
+
   persistentProps: Dict<any>;
   changedProps: Dict<any> = {};
   keys: Dict<any> | undefined;
@@ -582,6 +629,62 @@ export function Model<
       >,
     ) {
       return await super.exists(filter);
+    }
+
+    static async find<M extends typeof ModelClass>(
+      this: M,
+      id: Keys[keyof Keys] extends KeyType.uuid ? string : number,
+    ) {
+      return (await super.find(id as number | string)) as InstanceType<M> &
+        PersistentProps &
+        Readonly<{ [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }>;
+    }
+
+    static async findOrFail<M extends typeof ModelClass>(
+      this: M,
+      filter: Filter<
+        PersistentProps & { [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }
+      >,
+    ) {
+      return (await super.findOrFail(filter)) as InstanceType<M> &
+        PersistentProps &
+        Readonly<{ [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }>;
+    }
+
+    static async findOrBuild<M extends typeof ModelClass>(
+      this: M,
+      filter: Filter<
+        PersistentProps & { [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }
+      >,
+      createProps: CreateProps,
+    ) {
+      return (await super.findOrBuild(filter, createProps)) as InstanceType<M> &
+        PersistentProps &
+        Readonly<{ [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }>;
+    }
+
+    static async firstOrCreate<M extends typeof ModelClass>(
+      this: M,
+      filter: Filter<
+        PersistentProps & { [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }
+      >,
+      createProps: Partial<CreateProps> = {},
+    ) {
+      return (await super.firstOrCreate(filter, createProps)) as InstanceType<M> &
+        PersistentProps &
+        Readonly<{ [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }>;
+    }
+
+    static async updateOrCreate<M extends typeof ModelClass>(
+      this: M,
+      filter: Filter<
+        PersistentProps & { [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }
+      >,
+      attrs: Partial<PersistentProps>,
+    ) {
+      return (await super.updateOrCreate(filter, attrs)) as InstanceType<M> &
+        PersistentProps &
+        Readonly<{ [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }>;
     }
 
     static build<M extends typeof ModelClass>(this: M, props: CreateProps) {

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -977,6 +977,151 @@ describe('Model', () => {
     });
   });
 
+  describe('.find', () => {
+    it('returns the record by primary key', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const record = await Klass.create({ foo: 'a' });
+      const found = await Klass.find(record.attributes().id);
+      expect(found.attributes().foo).toBe('a');
+      storage = {};
+    });
+
+    it('throws NotFoundError when the record is absent', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      await expect(Klass.find(999)).rejects.toThrow(/not found/);
+      storage = {};
+    });
+  });
+
+  describe('.findOrFail', () => {
+    it('returns the matching record', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      await Klass.create({ foo: 'match' });
+      const found = await Klass.findOrFail({ foo: 'match' });
+      expect(found.attributes().foo).toBe('match');
+      storage = {};
+    });
+
+    it('throws when no record matches', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      await expect(Klass.findOrFail({ foo: 'missing' })).rejects.toThrow('Record not found');
+      storage = {};
+    });
+  });
+
+  describe('.findOrBuild', () => {
+    it('returns the existing record when found', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      await Klass.create({ foo: 'a', bar: 1 });
+      const record = await Klass.findOrBuild({ foo: 'a' }, { bar: 99 });
+      expect(record.attributes().bar).toBe(1);
+      expect(record.isNew()).toBe(false);
+      storage = {};
+    });
+
+    it('builds an unsaved instance when not found', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const record = await Klass.findOrBuild({ foo: 'missing' }, { bar: 42 });
+      expect(record.attributes().foo).toBe('missing');
+      expect(record.attributes().bar).toBe(42);
+      expect(record.isNew()).toBe(true);
+      expect(await Klass.count()).toBe(0);
+      storage = {};
+    });
+  });
+
+  describe('.firstOrCreate', () => {
+    it('returns the existing record without writing', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      await Klass.create({ foo: 'a' });
+      const before = await Klass.count();
+      const record = await Klass.firstOrCreate({ foo: 'a' }, { bar: 1 });
+      expect(record.attributes().foo).toBe('a');
+      expect(await Klass.count()).toBe(before);
+      storage = {};
+    });
+
+    it('creates when no record matches', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const record = await Klass.firstOrCreate({ foo: 'new' }, { bar: 42 });
+      expect(record.attributes().foo).toBe('new');
+      expect(record.attributes().bar).toBe(42);
+      expect(record.isPersistent()).toBe(true);
+      storage = {};
+    });
+  });
+
+  describe('.updateOrCreate', () => {
+    it('updates the existing record', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const original = await Klass.create({ foo: 'a', bar: 1 });
+      const record = await Klass.updateOrCreate({ foo: 'a' }, { bar: 99 });
+      expect(record.attributes().id).toBe(original.attributes().id);
+      expect(record.attributes().bar).toBe(99);
+      expect(await Klass.count()).toBe(1);
+      storage = {};
+    });
+
+    it('creates when no record matches', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const record = await Klass.updateOrCreate({ foo: 'new' }, { bar: 7 });
+      expect(record.attributes().foo).toBe('new');
+      expect(record.attributes().bar).toBe(7);
+      expect(record.isPersistent()).toBe(true);
+      storage = {};
+    });
+  });
+
   describe('#update', () => {
     it('assigns and saves in one call', async () => {
       storage = {};


### PR DESCRIPTION
## Summary
- `find(id)` — lookup by primary key; throws `NotFoundError` when missing.
- `findOrFail(filter)` — like `findBy` but throws instead of returning `undefined`.
- `findOrBuild(filter, createProps)` — returns matching record, or builds an unsaved instance seeded from `filter` + `createProps`.
- `firstOrCreate(filter, createProps)` — finds or persists.
- `updateOrCreate(filter, attrs)` — upsert: updates the matching record or creates one from `filter` + `attrs`.

## Test plan
- [x] `find(id)` returns the row / throws on miss
- [x] `findOrFail` returns / throws
- [x] `findOrBuild` returns existing OR builds unsaved with merged props
- [x] `firstOrCreate` does not write on hit, persists on miss
- [x] `updateOrCreate` updates existing, creates on miss, count stays at 1

Stacked on #53 (PR 11).