### PR TITLE
PR 13: hasManyThrough + increment/decrement

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -21,6 +21,13 @@ export type AssociationOptions = {
   primaryKey?: string;
 };
 
+export type HasManyThroughOptions = {
+  throughForeignKey?: string;
+  targetForeignKey?: string;
+  selfPrimaryKey?: string;
+  targetPrimaryKey?: string;
+};
+
 export class ModelClass {
   static tableName: string;
   static filter: Filter<any> | undefined;
@@ -92,14 +99,19 @@ export class ModelClass {
   }
 
   static filterBy<M extends typeof ModelClass>(this: M, andFilter: Filter<any>) {
+    const hasSpecial = (f: Filter<any>) => Object.keys(f).some((k) => k.startsWith('$'));
     let filter: Filter<any> | undefined = andFilter;
     if (this.filter) {
-      for (const key in this.filter) {
-        if ((this.filter as any)[key] !== undefined && (andFilter as any)[key] !== undefined) {
-          filter = { $and: [filter, andFilter] };
-          break;
+      if (hasSpecial(this.filter) || hasSpecial(andFilter)) {
+        filter = { $and: [this.filter, andFilter] };
+      } else {
+        for (const key in this.filter) {
+          if ((this.filter as any)[key] !== undefined && (andFilter as any)[key] !== undefined) {
+            filter = { $and: [filter, andFilter] };
+            break;
+          }
+          (filter as any)[key] = (this.filter as any)[key];
         }
-        (filter as any)[key] = (this.filter as any)[key];
       }
     }
     if (Object.keys(andFilter).length === 0) filter = this.filter;
@@ -364,6 +376,37 @@ export class ModelClass {
       return Promise.resolve(undefined);
     }
     return Related.findBy({ [fk]: pkValue }) as Promise<InstanceType<Related> | undefined>;
+  }
+
+  hasManyThrough<Target extends typeof ModelClass, Through extends typeof ModelClass>(
+    this: ModelClass,
+    Target: Target,
+    Through: Through,
+    options: HasManyThroughOptions = {},
+  ): Target {
+    const selfModel = this.constructor as typeof ModelClass;
+    const throughFk = options.throughForeignKey ?? `${singularize(selfModel.tableName)}Id`;
+    const targetFk = options.targetForeignKey ?? `${singularize(Target.tableName)}Id`;
+    const selfPk = options.selfPrimaryKey ?? Object.keys(selfModel.keys)[0] ?? 'id';
+    const targetPk = options.targetPrimaryKey ?? Object.keys(Target.keys)[0] ?? 'id';
+    const selfPkValue = (this as any)[selfPk];
+    const asyncPending = (async () => {
+      const ids = await Through.filterBy({ [throughFk]: selfPkValue }).pluck(targetFk);
+      return { $in: { [targetPk]: ids } } as Filter<any>;
+    })();
+    return Target.filterBy({ $async: asyncPending } as Filter<any>) as Target;
+  }
+
+  async increment<M extends ModelClass>(this: M, key: string, by = 1) {
+    if (!this.keys) {
+      throw new PersistenceError('Cannot increment a record that has not been saved');
+    }
+    const current = Number((this.attributes() as Dict<any>)[key] ?? 0);
+    return this.update({ [key]: current + by });
+  }
+
+  async decrement<M extends ModelClass>(this: M, key: string, by = 1) {
+    return this.increment(key, -by);
   }
 
   async isValid(): Promise<boolean> {

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -1122,6 +1122,74 @@ describe('Model', () => {
     });
   });
 
+  describe('#increment / #decrement', () => {
+    it('increments the given field and persists', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const record = await Klass.create({ count: 5 });
+      await record.increment('count');
+      expect(record.attributes().count).toBe(6);
+      const reloaded = (await Klass.findBy({ id: record.attributes().id }))!;
+      expect(reloaded.attributes().count).toBe(6);
+      storage = {};
+    });
+
+    it('accepts a custom step', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const record = await Klass.create({ count: 10 });
+      await record.increment('count', 3);
+      expect(record.attributes().count).toBe(13);
+      storage = {};
+    });
+
+    it('decrements the field', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const record = await Klass.create({ count: 5 });
+      await record.decrement('count', 2);
+      expect(record.attributes().count).toBe(3);
+      storage = {};
+    });
+
+    it('treats missing values as zero', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const record = await Klass.create({});
+      await record.increment('count');
+      expect(record.attributes().count).toBe(1);
+      storage = {};
+    });
+
+    it('throws when the record is unsaved', async () => {
+      const Klass = Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+      const record = Klass.build({ count: 1 });
+      await expect(record.increment('count')).rejects.toThrow(
+        'Cannot increment a record that has not been saved',
+      );
+    });
+  });
+
   describe('#update', () => {
     it('assigns and saves in one call', async () => {
       storage = {};
@@ -1399,6 +1467,116 @@ describe('Model', () => {
         await PostKlass.create({ authorId: user.id, title: 'A' });
         const posts = await user.hasMany(PostKlass, { foreignKey: 'authorId' }).all();
         expect(posts).toHaveLength(1);
+      });
+    });
+
+    describe('#hasManyThrough', () => {
+      it('returns target records linked via the join table', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { title: string }) => props,
+          connector: assocConnector(),
+        });
+        const AuthorshipKlass = Model({
+          tableName: 'authorships',
+          init: (props: { userId: number; postId: number }) => props,
+          connector: assocConnector(),
+        });
+        const alice = await UserKlass.create({ name: 'Alice' });
+        const bob = await UserKlass.create({ name: 'Bob' });
+        const postA = await PostKlass.create({ title: 'A' });
+        const postB = await PostKlass.create({ title: 'B' });
+        const postC = await PostKlass.create({ title: 'C' });
+        await AuthorshipKlass.create({ userId: alice.id, postId: postA.id });
+        await AuthorshipKlass.create({ userId: alice.id, postId: postB.id });
+        await AuthorshipKlass.create({ userId: bob.id, postId: postC.id });
+
+        const alicePosts = await alice.hasManyThrough(PostKlass, AuthorshipKlass).all();
+        expect(alicePosts.map((p) => p.attributes().title).sort()).toEqual(['A', 'B']);
+      });
+
+      it('supports further chained scopes on the returned class', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { title: string; published: boolean }) => props,
+          connector: assocConnector(),
+        });
+        const AuthorshipKlass = Model({
+          tableName: 'authorships',
+          init: (props: { userId: number; postId: number }) => props,
+          connector: assocConnector(),
+        });
+        const alice = await UserKlass.create({ name: 'Alice' });
+        const postA = await PostKlass.create({ title: 'A', published: true });
+        const postB = await PostKlass.create({ title: 'B', published: false });
+        await AuthorshipKlass.create({ userId: alice.id, postId: postA.id });
+        await AuthorshipKlass.create({ userId: alice.id, postId: postB.id });
+
+        const published = await alice
+          .hasManyThrough(PostKlass, AuthorshipKlass)
+          .filterBy({ published: true })
+          .all();
+        expect(published).toHaveLength(1);
+        expect(published[0].attributes().title).toBe('A');
+      });
+
+      it('returns an empty result when no join rows match', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { title: string }) => props,
+          connector: assocConnector(),
+        });
+        const AuthorshipKlass = Model({
+          tableName: 'authorships',
+          init: (props: { userId: number; postId: number }) => props,
+          connector: assocConnector(),
+        });
+        const alice = await UserKlass.create({ name: 'Alice' });
+        const posts = await alice.hasManyThrough(PostKlass, AuthorshipKlass).all();
+        expect(posts).toHaveLength(0);
+      });
+
+      it('honours custom foreignKeys', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { title: string }) => props,
+          connector: assocConnector(),
+        });
+        const AuthorshipKlass = Model({
+          tableName: 'authorships',
+          init: (props: { authorId: number; articleId: number }) => props,
+          connector: assocConnector(),
+        });
+        const alice = await UserKlass.create({ name: 'Alice' });
+        const postA = await PostKlass.create({ title: 'A' });
+        await AuthorshipKlass.create({ authorId: alice.id, articleId: postA.id });
+        const posts = await alice
+          .hasManyThrough(PostKlass, AuthorshipKlass, {
+            throughForeignKey: 'authorId',
+            targetForeignKey: 'articleId',
+          })
+          .all();
+        expect(posts.map((p) => p.attributes().title)).toEqual(['A']);
       });
     });
 


### PR DESCRIPTION
## Summary
- `hasManyThrough(Target, Through, options?)` instance method for join-table associations. Uses the `\$async` filter so the returned scoped class supports further `.filterBy`, `.all`, `.count`, etc. without awaiting the intermediate.
- `increment(key, by = 1)` / `decrement(key, by = 1)` instance methods. Treat missing values as 0 and persist via `update()`.
- Bugfix in `filterBy`: if either side has \$-operators, combine with `\$and` instead of shallow-merging. Previously mixing \$-ops with plain props produced invalid filters (`"special filter expects exactly one operator"`).

## Test plan
- [x] `hasManyThrough` returns target records linked via the join table
- [x] Scoped class can be further chained with `.filterBy({...}).all()`
- [x] Empty join set returns `[]`
- [x] Custom `throughForeignKey` / `targetForeignKey` honored
- [x] `increment`/`decrement` persist, accept custom step, treat undefined as 0
- [x] `increment` throws on unsaved records

Stacked on #54 (PR 12).