### PR TITLE
PR 14: Aggregates (sum / min / max / avg)

### DIFF
--- a/packages/core/src/MemoryConnector.ts
+++ b/packages/core/src/MemoryConnector.ts
@@ -1,5 +1,6 @@
 import { filterList } from './FilterEngine';
 import {
+  type AggregateKind,
   type BaseType,
   type Connector,
   type Dict,
@@ -152,6 +153,24 @@ export class MemoryConnector implements Connector {
       result.push(clone(attributes));
     }
     return result;
+  }
+
+  async aggregate(scope: Scope, kind: AggregateKind, key: string): Promise<number | undefined> {
+    const items = await this.items(scope);
+    const values = items
+      .map((item) => item[key])
+      .filter((v): v is number => typeof v === 'number' && !Number.isNaN(v));
+    if (values.length === 0) return undefined;
+    switch (kind) {
+      case 'sum':
+        return values.reduce((acc, v) => acc + v, 0);
+      case 'min':
+        return Math.min(...values);
+      case 'max':
+        return Math.max(...values);
+      case 'avg':
+        return values.reduce((acc, v) => acc + v, 0) / values.length;
+    }
   }
 
   async execute(query: string, bindings: BaseType | BaseType[]): Promise<any[]> {

--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -1,5 +1,6 @@
 import { NotFoundError, PersistenceError, ValidationError } from './errors';
 import {
+  type AggregateKind,
   type Callback,
   type Callbacks,
   type Connector,
@@ -183,6 +184,30 @@ export class ModelClass {
 
   static async count<M extends typeof ModelClass>(this: M) {
     return await this.connector.count(this.modelScope());
+  }
+
+  static async aggregate<M extends typeof ModelClass>(
+    this: M,
+    kind: AggregateKind,
+    key: string,
+  ): Promise<number | undefined> {
+    return await this.connector.aggregate(this.modelScope(), kind, key);
+  }
+
+  static async sum<M extends typeof ModelClass>(this: M, key: string) {
+    return (await this.aggregate('sum', key)) ?? 0;
+  }
+
+  static async min<M extends typeof ModelClass>(this: M, key: string) {
+    return this.aggregate('min', key);
+  }
+
+  static async max<M extends typeof ModelClass>(this: M, key: string) {
+    return this.aggregate('max', key);
+  }
+
+  static async avg<M extends typeof ModelClass>(this: M, key: string) {
+    return this.aggregate('avg', key);
   }
 
   static async deleteAll<M extends typeof ModelClass>(this: M) {
@@ -640,6 +665,22 @@ export function Model<
 
     static async count<M extends typeof ModelClass>(this: M) {
       return await super.count();
+    }
+
+    static async sum<M extends typeof ModelClass>(this: M, key: keyof PersistentProps) {
+      return super.sum(key as string);
+    }
+
+    static async min<M extends typeof ModelClass>(this: M, key: keyof PersistentProps) {
+      return super.min(key as string);
+    }
+
+    static async max<M extends typeof ModelClass>(this: M, key: keyof PersistentProps) {
+      return super.max(key as string);
+    }
+
+    static async avg<M extends typeof ModelClass>(this: M, key: keyof PersistentProps) {
+      return super.avg(key as string);
     }
 
     static async deleteAll<M extends typeof ModelClass>(this: M) {

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -977,6 +977,69 @@ describe('Model', () => {
     });
   });
 
+  describe('aggregates', () => {
+    const buildKlass = () => {
+      storage = {};
+      return Model({
+        tableName,
+        init: (props: any) => props,
+        connector: connector(),
+      });
+    };
+
+    it('#sum adds numeric values in scope', async () => {
+      const Klass = buildKlass();
+      await Klass.create({ n: 1 });
+      await Klass.create({ n: 2 });
+      await Klass.create({ n: 4 });
+      expect(await Klass.sum('n')).toBe(7);
+      storage = {};
+    });
+
+    it('#sum returns 0 for empty result', async () => {
+      const Klass = buildKlass();
+      expect(await Klass.sum('n')).toBe(0);
+      storage = {};
+    });
+
+    it('#min and #max return the bounds', async () => {
+      const Klass = buildKlass();
+      await Klass.create({ n: 3 });
+      await Klass.create({ n: 1 });
+      await Klass.create({ n: 8 });
+      expect(await Klass.min('n')).toBe(1);
+      expect(await Klass.max('n')).toBe(8);
+      storage = {};
+    });
+
+    it('#avg returns the mean of numeric values', async () => {
+      const Klass = buildKlass();
+      await Klass.create({ n: 2 });
+      await Klass.create({ n: 4 });
+      await Klass.create({ n: 6 });
+      expect(await Klass.avg('n')).toBe(4);
+      storage = {};
+    });
+
+    it('returns undefined when no numeric values exist', async () => {
+      const Klass = buildKlass();
+      await Klass.create({ n: 'not-a-number' });
+      expect(await Klass.min('n')).toBeUndefined();
+      expect(await Klass.max('n')).toBeUndefined();
+      expect(await Klass.avg('n')).toBeUndefined();
+      storage = {};
+    });
+
+    it('respects the current filter scope', async () => {
+      const Klass = buildKlass();
+      await Klass.create({ group: 1, n: 10 });
+      await Klass.create({ group: 1, n: 20 });
+      await Klass.create({ group: 2, n: 999 });
+      expect(await Klass.filterBy({ group: 1 }).sum('n')).toBe(30);
+      storage = {};
+    });
+  });
+
   describe('.find', () => {
     it('returns the record by primary key', async () => {
       storage = {};

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -75,6 +75,8 @@ export type Order<PersistentProps extends Schema> =
   | OrderColumn<PersistentProps>
   | OrderColumn<PersistentProps>[];
 
+export type AggregateKind = 'sum' | 'min' | 'max' | 'avg';
+
 export interface Connector {
   query(scope: Scope): Promise<Dict<any>[]>;
   count(scope: Scope): Promise<number>;
@@ -84,6 +86,7 @@ export interface Connector {
   batchInsert(tableName: string, keys: Dict<KeyType>, items: Dict<any>[]): Promise<Dict<any>[]>;
   execute(query: string, bindings: BaseType | BaseType[]): Promise<any[]>;
   transaction<T>(fn: () => Promise<T>): Promise<T>;
+  aggregate(scope: Scope, kind: AggregateKind, key: string): Promise<number | undefined>;
 }
 
 export interface Scope {


### PR DESCRIPTION
## Summary
- New `Connector.aggregate(scope, kind, key)` contract returning `number | undefined`.
- `MemoryConnector` implementation filters to numeric values (ignores strings/NaN so mixed columns don't blow up).
- `ModelClass` gains `sum`, `min`, `max`, `avg` statics plus the generic `aggregate(kind, key)` escape hatch. `sum` returns `0` on empty sets; `min`/`max`/`avg` return `undefined`.
- Typed factory subclass narrows the key to `keyof PersistentProps`.

## Test plan
- [x] `sum` sums in scope; empty → 0
- [x] `min`/`max` return bounds
- [x] `avg` returns the mean
- [x] Non-numeric-only column → `undefined` for min/max/avg
- [x] Filter scope respected (`filterBy(...).sum(...)`)

Stacked on #55 (PR 13).