### PR TITLE
PR 15: Named scopes

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -29,6 +29,14 @@ export type HasManyThroughOptions = {
   targetPrimaryKey?: string;
 };
 
+export type ScopeFn<Self> = (self: Self, ...args: any[]) => Self;
+
+export type ScopeMap<Self> = Dict<ScopeFn<Self>>;
+
+export type ScopesToMethods<Self, S extends ScopeMap<Self>> = {
+  [K in keyof S]: (...args: S[K] extends (self: any, ...rest: infer R) => any ? R : never) => Self;
+};
+
 export class ModelClass {
   static tableName: string;
   static filter: Filter<any> | undefined;
@@ -564,6 +572,7 @@ export function Model<
   CreateProps = {},
   PersistentProps extends Schema = {},
   Keys extends Dict<KeyType> = { id: KeyType.number },
+  Scopes extends ScopeMap<any> = {},
 >(props: {
   tableName: string;
   init: (props: CreateProps) => PersistentProps;
@@ -584,6 +593,7 @@ export function Model<
   callbacks?: Callbacks<
     PersistentProps & { [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }
   >;
+  scopes?: Scopes;
 }) {
   const connector = props.connector ? props.connector : new MemoryConnector();
   const order = props.order ? (Array.isArray(props.order) ? props.order : [props.order]) : [];
@@ -591,8 +601,9 @@ export function Model<
   const timestamps = props.timestamps ?? true;
   const validators = props.validators || [];
   const callbacks = props.callbacks || {};
+  const scopeDefs = props.scopes || ({} as Scopes);
 
-  return class Model extends ModelClass {
+  const ModelSubclass = class Model extends ModelClass {
     static tableName = props.tableName;
     static filter = props.filter;
     static limit = props.limit;
@@ -838,6 +849,14 @@ export function Model<
       return super.update(attrs as Dict<any>) as Promise<M>;
     }
   };
+
+  for (const name in scopeDefs) {
+    (ModelSubclass as any)[name] = function (this: typeof ModelSubclass, ...args: any[]) {
+      return scopeDefs[name](this, ...args);
+    };
+  }
+
+  return ModelSubclass as typeof ModelSubclass & ScopesToMethods<typeof ModelSubclass, Scopes>;
 }
 
 export default Model;

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -1696,6 +1696,85 @@ describe('Model', () => {
     });
   });
 
+  describe('scopes', () => {
+    let scopeStorage: Storage = {};
+    const scopeConnector = () => new MemoryConnector({ storage: scopeStorage });
+
+    beforeEach(() => {
+      scopeStorage = {};
+    });
+
+    it('registers scope as static method returning scoped class', async () => {
+      const Klass = Model({
+        tableName: 'posts',
+        init: (props: { title: string; published: boolean }) => props,
+        connector: scopeConnector(),
+        scopes: {
+          published: (self) => self.filterBy({ published: true }),
+        },
+      });
+      await Klass.create({ title: 'A', published: true });
+      await Klass.create({ title: 'B', published: false });
+      const results = await Klass.published().all();
+      expect(results).toHaveLength(1);
+      expect(results[0].attributes().title).toBe('A');
+    });
+
+    it('supports parameterized scopes', async () => {
+      const Klass = Model({
+        tableName: 'posts',
+        init: (props: { title: string; views: number }) => props,
+        connector: scopeConnector(),
+        scopes: {
+          minViews: (self, threshold: number) =>
+            self.filterBy({ $gte: { views: threshold } } as Filter<any>),
+        },
+      });
+      await Klass.create({ title: 'A', views: 5 });
+      await Klass.create({ title: 'B', views: 50 });
+      await Klass.create({ title: 'C', views: 100 });
+      const popular = await Klass.minViews(50).all();
+      expect(popular.map((p) => p.attributes().title).sort()).toEqual(['B', 'C']);
+    });
+
+    it('allows chaining scopes with other queries', async () => {
+      const Klass = Model({
+        tableName: 'posts',
+        init: (props: { title: string; published: boolean; views: number }) => props,
+        connector: scopeConnector(),
+        scopes: {
+          published: (self) => self.filterBy({ published: true }),
+        },
+      });
+      await Klass.create({ title: 'A', published: true, views: 10 });
+      await Klass.create({ title: 'B', published: true, views: 5 });
+      await Klass.create({ title: 'C', published: false, views: 100 });
+      const hits = await Klass.published()
+        .filterBy({ $gte: { views: 10 } } as Filter<any>)
+        .all();
+      expect(hits).toHaveLength(1);
+      expect(hits[0].attributes().title).toBe('A');
+    });
+
+    it('composes multiple scopes together', async () => {
+      const Klass = Model({
+        tableName: 'posts',
+        init: (props: { title: string; published: boolean; featured: boolean }) => props,
+        connector: scopeConnector(),
+        scopes: {
+          published: (self) => self.filterBy({ published: true }),
+          featured: (self) => self.filterBy({ featured: true }),
+        },
+      });
+      await Klass.create({ title: 'A', published: true, featured: true });
+      await Klass.create({ title: 'B', published: true, featured: false });
+      await Klass.create({ title: 'C', published: false, featured: true });
+      const results = await Klass.published().featured().all();
+      expect(results).toHaveLength(1);
+      expect(results[0].attributes().title).toBe('A');
+    });
+  });
+
   // describe('.order', () => {
   //   let Klass: typeof Model;
   //   let order: Partial<Order<any>>[] = Faker.order;


### PR DESCRIPTION
## Summary

Adds named scopes to the Model factory. Users can declare reusable filter/order combinations as factory options, callable as class methods that return scoped classes for further chaining.

```ts
const Post = Model({
  tableName: 'posts',
  init: (props) => props,
  scopes: {
    published: (self) => self.filterBy({ published: true }),
    minViews: (self, threshold: number) =>
      self.filterBy({ \$gte: { views: threshold } }),
  },
});

await Post.published().all();
await Post.minViews(100).filterBy({ published: true }).all();
```

Each scope:
- Receives the invoking class as `self`
- Returns a scoped class (typically via `filterBy` / `orderBy`)
- Chains with other queries, scopes, aggregates, and terminators

Stacks on PR 14 (aggregates).

## Test plan
- [x] `pnpm typecheck` (3 packages)
- [x] `pnpm --filter @next-model/core test` — 5162 passing
- [x] `pnpm biome check packages/core/src`
- [x] Tests cover: basic scope, parameterized scope, chaining with filterBy, composing multiple scopes