### PR TITLE
PR 16: Batch ops + query shortcuts

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -163,6 +163,27 @@ export class ModelClass {
     return this.buildScoped<M>(props).save();
   }
 
+  static async createMany<M extends typeof ModelClass>(this: M, propsList: any[]) {
+    const now = new Date();
+    const insertProps = propsList.map((p) => {
+      const base = this.init(p) as Dict<any>;
+      if (this.timestamps) {
+        if (base.createdAt === undefined) base.createdAt = now;
+        if (base.updatedAt === undefined) base.updatedAt = now;
+      }
+      return base;
+    });
+    const items = await this.connector.batchInsert(this.tableName, this.keys, insertProps);
+    return items.map((item) => {
+      const keys: Dict<any> = {};
+      for (const key in this.keys) {
+        keys[key] = item[key];
+        delete item[key];
+      }
+      return new this(item, keys) as InstanceType<M>;
+    });
+  }
+
   static async all<M extends typeof ModelClass>(this: M) {
     const items = await this.connector.query(this.modelScope());
     return items.map((item) => {
@@ -180,6 +201,18 @@ export class ModelClass {
     return items.pop();
   }
 
+  static async last<M extends typeof ModelClass>(this: M) {
+    const primaryKey = Object.keys(this.keys)[0] ?? 'id';
+    const scoped = this.order.length > 0 ? this : (this.orderBy({ key: primaryKey }) as M);
+    const items = await scoped.all<M>();
+    return items.pop();
+  }
+
+  static async ids<M extends typeof ModelClass>(this: M) {
+    const primaryKey = Object.keys(this.keys)[0] ?? 'id';
+    return this.pluck(primaryKey);
+  }
+
   static async select(...keys: any[]) {
     const items = await this.connector.select(this.modelScope(), ...keys);
     return items;
@@ -188,6 +221,19 @@ export class ModelClass {
   static async pluck(key: string) {
     const items = await this.select(key as any);
     return items.map((item) => item[key]);
+  }
+
+  static async pluckUnique(key: string) {
+    const values = await this.pluck(key);
+    const seen = new Set<any>();
+    const result: any[] = [];
+    for (const v of values) {
+      if (!seen.has(v)) {
+        seen.add(v);
+        result.push(v);
+      }
+    }
+    return result;
   }
 
   static async count<M extends typeof ModelClass>(this: M) {
@@ -662,6 +708,14 @@ export function Model<
       return super.pluck(key as string);
     }
 
+    static async pluckUnique(key: keyof Keys | keyof PersistentProps) {
+      return super.pluckUnique(key as string);
+    }
+
+    static async ids<M extends typeof ModelClass>(this: M) {
+      return super.ids();
+    }
+
     static async all<M extends typeof ModelClass>(this: M) {
       return (await super.all()) as (InstanceType<M> &
         PersistentProps &
@@ -670,6 +724,12 @@ export function Model<
 
     static async first<M extends typeof ModelClass>(this: M) {
       return (await super.first()) as InstanceType<M> &
+        PersistentProps &
+        Readonly<{ [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }>;
+    }
+
+    static async last<M extends typeof ModelClass>(this: M) {
+      return (await super.last()) as InstanceType<M> &
         PersistentProps &
         Readonly<{ [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }>;
     }
@@ -804,6 +864,12 @@ export function Model<
       return (await super.createScoped(props)) as InstanceType<M> &
         PersistentProps &
         Readonly<{ [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }>;
+    }
+
+    static async createMany<M extends typeof ModelClass>(this: M, propsList: CreateProps[]) {
+      return (await super.createMany(propsList)) as (InstanceType<M> &
+        PersistentProps &
+        Readonly<{ [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }>)[];
     }
 
     persistentProps: PersistentProps;

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -1775,6 +1775,127 @@ describe('Model', () => {
     });
   });
 
+  describe('.createMany', () => {
+    const buildKlass = () => {
+      storage = {};
+      return Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+      });
+    };
+
+    it('inserts each record and returns persisted instances', async () => {
+      const Klass = buildKlass();
+      const results = await Klass.createMany([{ foo: 'a' }, { foo: 'b' }, { foo: 'c' }]);
+      expect(results).toHaveLength(3);
+      for (const r of results) {
+        expect(r.isPersistent()).toBe(true);
+      }
+      expect(results.map((r) => r.attributes().foo).sort()).toEqual(['a', 'b', 'c']);
+      expect(await Klass.count()).toBe(3);
+      storage = {};
+    });
+
+    it('assigns distinct primary keys', async () => {
+      const Klass = buildKlass();
+      const results = await Klass.createMany([{ foo: 'a' }, { foo: 'b' }]);
+      const ids = results.map((r) => r.attributes().id);
+      expect(new Set(ids).size).toBe(2);
+      storage = {};
+    });
+
+    it('applies timestamps to each row', async () => {
+      const Klass = buildKlass();
+      const results = await Klass.createMany([{ foo: 'a' }, { foo: 'b' }]);
+      for (const r of results) {
+        expect(r.attributes().createdAt).toBeInstanceOf(Date);
+        expect(r.attributes().updatedAt).toBeInstanceOf(Date);
+      }
+      storage = {};
+    });
+
+    it('returns empty array when given empty input', async () => {
+      const Klass = buildKlass();
+      const results = await Klass.createMany([]);
+      expect(results).toEqual([]);
+      storage = {};
+    });
+  });
+
+  describe('.last', () => {
+    const buildKlass = () => {
+      storage = {};
+      return Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+      });
+    };
+
+    it('returns the last record by primary key when no order is set', async () => {
+      const Klass = buildKlass();
+      await Klass.create({ foo: 'a' });
+      await Klass.create({ foo: 'b' });
+      await Klass.create({ foo: 'c' });
+      const last = await Klass.last();
+      expect(last?.attributes().foo).toBe('c');
+      storage = {};
+    });
+
+    it('reverses the existing order', async () => {
+      const Klass = buildKlass();
+      await Klass.create({ foo: 'c' });
+      await Klass.create({ foo: 'a' });
+      await Klass.create({ foo: 'b' });
+      const last = await Klass.orderBy({ key: 'foo' as any }).last();
+      expect(last?.attributes().foo).toBe('c');
+      storage = {};
+    });
+
+    it('returns undefined when no records exist', async () => {
+      const Klass = buildKlass();
+      const last = await Klass.last();
+      expect(last).toBeUndefined();
+      storage = {};
+    });
+  });
+
+  describe('.ids', () => {
+    it('returns the primary keys within the current scope', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+      });
+      const a = await Klass.create({ foo: 'a' });
+      const b = await Klass.create({ foo: 'b' });
+      const ids = await Klass.ids();
+      expect(ids.sort()).toEqual([a.attributes().id, b.attributes().id].sort());
+      storage = {};
+    });
+  });
+
+  describe('.pluckUnique', () => {
+    it('returns deduplicated values preserving first-seen order', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { tag: string }) => props,
+        connector: connector(),
+      });
+      await Klass.create({ tag: 'x' });
+      await Klass.create({ tag: 'y' });
+      await Klass.create({ tag: 'x' });
+      await Klass.create({ tag: 'z' });
+      await Klass.create({ tag: 'y' });
+      const tags = await Klass.pluckUnique('tag');
+      expect(tags).toEqual(['x', 'y', 'z']);
+      storage = {};
+    });
+  });
+
   // describe('.order', () => {
   //   let Klass: typeof Model;
   //   let order: Partial<Order<any>>[] = Faker.order;


### PR DESCRIPTION
## Summary

Rounds out the query API with batch operations and common shortcuts.

- **`createMany(propsList)`** — batch-insert in a single connector call. Runs each row through `init`, applies timestamps, and returns persisted instances.
- **`last()`** — returns the last matching record. Uses the existing order if set; otherwise falls back to primary-key order.
- **`ids()`** — returns the primary keys within the current scope (shortcut over `pluck('id')`).
- **`pluckUnique(key)`** — like `pluck` but deduplicates while preserving first-seen order.

```ts
const users = await User.createMany([{ name: 'A' }, { name: 'B' }]);
const latest = await Post.last();
const authorIds = await Post.pluckUnique('authorId');
const postIds = await Post.filterBy({ published: true }).ids();
```

Stacks on PR 15 (named scopes).

## Test plan
- [x] `pnpm typecheck` (3 packages)
- [x] `pnpm --filter @next-model/core test` — 5171 passing
- [x] `pnpm biome check packages/core/src`
- [x] Tests cover: batch insert, PK uniqueness, timestamps, empty-input, last with/without order, ids in scope, pluckUnique ordering