### PR TITLE
PR 17: Soft deletes

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -47,6 +47,7 @@ export class ModelClass {
   static connector: Connector;
   static init: (props: any) => Dict<any>;
   static timestamps = true;
+  static softDelete: 'active' | 'only' | false = false;
   static validators: Validator<any>[] = [];
   static callbacks: Callbacks<any> = {};
 
@@ -55,9 +56,17 @@ export class ModelClass {
   }
 
   static modelScope() {
+    let filter = this.filter;
+    if (this.softDelete === 'active') {
+      filter = filter ? { $and: [{ $null: 'discardedAt' }, filter] } : { $null: 'discardedAt' };
+    } else if (this.softDelete === 'only') {
+      filter = filter
+        ? { $and: [{ $notNull: 'discardedAt' }, filter] }
+        : { $notNull: 'discardedAt' };
+    }
     return {
       tableName: this.tableName,
-      filter: this.filter,
+      filter,
       limit: this.limit,
       skip: this.skip,
       order: this.order,
@@ -144,6 +153,18 @@ export class ModelClass {
   static unfiltered<M extends typeof ModelClass>(this: M) {
     return class extends (this as typeof ModelClass) {
       static filter = undefined;
+    } as M;
+  }
+
+  static withDiscarded<M extends typeof ModelClass>(this: M) {
+    return class extends (this as typeof ModelClass) {
+      static softDelete: 'active' | 'only' | false = false;
+    } as M;
+  }
+
+  static onlyDiscarded<M extends typeof ModelClass>(this: M) {
+    return class extends (this as typeof ModelClass) {
+      static softDelete: 'active' | 'only' | false = 'only';
     } as M;
   }
 
@@ -612,6 +633,27 @@ export class ModelClass {
     await this.runCallbacks('afterDelete');
     return this as M;
   }
+
+  isDiscarded(): boolean {
+    const value = (this.attributes() as Dict<any>).discardedAt;
+    return value !== null && value !== undefined;
+  }
+
+  async discard<M extends ModelClass>(this: M): Promise<M> {
+    if (!this.keys) {
+      throw new PersistenceError('Cannot discard a record that has not been saved');
+    }
+    (this as ModelClass).assign({ discardedAt: new Date() } as Dict<any>);
+    return (this as ModelClass).save() as Promise<M>;
+  }
+
+  async restore<M extends ModelClass>(this: M): Promise<M> {
+    if (!this.keys) {
+      throw new PersistenceError('Cannot restore a record that has not been saved');
+    }
+    (this as ModelClass).assign({ discardedAt: null } as Dict<any>);
+    return (this as ModelClass).save() as Promise<M>;
+  }
 }
 
 export function Model<
@@ -633,6 +675,7 @@ export function Model<
   connector?: Connector;
   keys?: Keys;
   timestamps?: boolean;
+  softDelete?: boolean;
   validators?: Validator<
     PersistentProps & { [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }
   >[];
@@ -645,6 +688,7 @@ export function Model<
   const order = props.order ? (Array.isArray(props.order) ? props.order : [props.order]) : [];
   const keyDefinitions = props.keys || { id: KeyType.number };
   const timestamps = props.timestamps ?? true;
+  const softDelete: 'active' | 'only' | false = props.softDelete ? 'active' : false;
   const validators = props.validators || [];
   const callbacks = props.callbacks || {};
   const scopeDefs = props.scopes || ({} as Scopes);
@@ -659,6 +703,7 @@ export function Model<
     static connector = connector;
     static init = props.init as any;
     static timestamps = timestamps;
+    static softDelete = softDelete;
     static validators = validators as Validator<any>[];
     static callbacks = callbacks as Callbacks<any>;
 

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -1896,6 +1896,102 @@ describe('Model', () => {
     });
   });
 
+  describe('soft deletes', () => {
+    const buildKlass = () => {
+      storage = {};
+      return Model({
+        tableName,
+        init: (props: { title: string; discardedAt?: Date | null }) => ({
+          discardedAt: null,
+          ...props,
+        }),
+        connector: connector(),
+        softDelete: true,
+      });
+    };
+
+    it('hides discarded records from the default scope', async () => {
+      const Klass = buildKlass();
+      const a = await Klass.create({ title: 'A' });
+      await Klass.create({ title: 'B' });
+      await a.discard();
+      const titles = (await Klass.all()).map((r) => r.attributes().title);
+      expect(titles).toEqual(['B']);
+      storage = {};
+    });
+
+    it('sets discardedAt to the current time when discarded', async () => {
+      const Klass = buildKlass();
+      const a = await Klass.create({ title: 'A' });
+      expect(a.isDiscarded()).toBe(false);
+      await a.discard();
+      expect(a.isDiscarded()).toBe(true);
+      expect(a.attributes().discardedAt).toBeInstanceOf(Date);
+      storage = {};
+    });
+
+    it('restore() clears discardedAt and brings the record back', async () => {
+      const Klass = buildKlass();
+      const a = await Klass.create({ title: 'A' });
+      await a.discard();
+      expect(await Klass.count()).toBe(0);
+      await a.restore();
+      expect(a.isDiscarded()).toBe(false);
+      expect(await Klass.count()).toBe(1);
+      storage = {};
+    });
+
+    it('withDiscarded() includes both active and discarded records', async () => {
+      const Klass = buildKlass();
+      const a = await Klass.create({ title: 'A' });
+      await Klass.create({ title: 'B' });
+      await a.discard();
+      const all = await Klass.withDiscarded().all();
+      expect(all.map((r) => r.attributes().title).sort()).toEqual(['A', 'B']);
+      storage = {};
+    });
+
+    it('onlyDiscarded() returns only discarded records', async () => {
+      const Klass = buildKlass();
+      const a = await Klass.create({ title: 'A' });
+      await Klass.create({ title: 'B' });
+      await a.discard();
+      const only = await Klass.onlyDiscarded().all();
+      expect(only.map((r) => r.attributes().title)).toEqual(['A']);
+      storage = {};
+    });
+
+    it('delete() still performs a hard delete when soft-delete is enabled', async () => {
+      const Klass = buildKlass();
+      const a = await Klass.create({ title: 'A' });
+      await a.delete();
+      expect(await Klass.withDiscarded().count()).toBe(0);
+      storage = {};
+    });
+
+    it('discard on an unsaved record throws', async () => {
+      const Klass = buildKlass();
+      const a = Klass.build({ title: 'A' });
+      await expect(a.discard()).rejects.toThrow();
+      storage = {};
+    });
+
+    it('does not apply soft-delete scope when the option is off', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { title: string; discardedAt?: Date | null }) => ({
+          discardedAt: null,
+          ...props,
+        }),
+        connector: connector(),
+      });
+      await Klass.create({ title: 'A', discardedAt: new Date() });
+      expect(await Klass.count()).toBe(1);
+      storage = {};
+    });
+  });
+
   // describe('.order', () => {
   //   let Klass: typeof Model;
   //   let order: Partial<Order<any>>[] = Faker.order;


### PR DESCRIPTION
## Summary

Adds opt-in soft delete support via a `softDelete: true` factory option.

When enabled:
- Default class scope excludes rows where `discardedAt` is non-null
- Instances gain `discard()`, `restore()`, `isDiscarded()`
- Classes gain `withDiscarded()` (active + discarded) and `onlyDiscarded()` (discarded only) scope modifiers
- `delete()` still performs a hard delete; `discard()` is explicit soft delete

```ts
const Post = Model({
  tableName: 'posts',
  init: (props: { title: string; discardedAt?: Date | null }) => ({
    discardedAt: null,
    ...props,
  }),
  softDelete: true,
});

const post = await Post.create({ title: 'Hello' });
await post.discard();                       // sets discardedAt = now
await Post.count();                         // 0 — hidden from default scope
await Post.withDiscarded().count();         // 1
await Post.onlyDiscarded().count();         // 1
await post.restore();                       // discardedAt = null
```

Schema-wise: users must ensure `discardedAt: Date | null` is part of their persistent props.

Stacks on PR 16 (batch ops).

## Test plan
- [x] `pnpm typecheck` (3 packages)
- [x] `pnpm --filter @next-model/core test` — 5179 passing
- [x] `pnpm biome check packages/core/src`
- [x] Tests cover: discard hides record, restore brings it back, withDiscarded / onlyDiscarded scopes, hard delete still works, unsaved-discard throws, scope is inactive when option is off