### PR TITLE
PR 18: Serialization helpers (toJSON, pick, omit)

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -389,6 +389,29 @@ export class ModelClass {
     return { ...this.persistentProps, ...this.changedProps, ...this.keys };
   }
 
+  toJSON(): Dict<any> {
+    return this.attributes();
+  }
+
+  pick(keys: string[]): Dict<any> {
+    const attrs = this.attributes();
+    const result: Dict<any> = {};
+    for (const key of keys) {
+      if (key in attrs) result[key] = attrs[key];
+    }
+    return result;
+  }
+
+  omit(keys: string[]): Dict<any> {
+    const attrs = this.attributes();
+    const skip = new Set(keys);
+    const result: Dict<any> = {};
+    for (const key in attrs) {
+      if (!skip.has(key)) result[key] = attrs[key];
+    }
+    return result;
+  }
+
   assign<M extends ModelClass>(this: M, props: Dict<any>) {
     for (const key in props) {
       if (this.persistentProps[key] !== props[key]) {
@@ -935,6 +958,24 @@ export function Model<
         ...(this.changedProps as object),
         ...(this.keys as object),
       } as PersistentProps & { [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number };
+    }
+
+    toJSON() {
+      return this.attributes();
+    }
+
+    pick<K extends keyof PersistentProps | keyof Keys>(keys: K[]) {
+      return super.pick(keys as string[]) as Pick<
+        PersistentProps & { [P in keyof Keys]: Keys[P] extends KeyType.uuid ? string : number },
+        K & (keyof PersistentProps | keyof Keys)
+      >;
+    }
+
+    omit<K extends keyof PersistentProps | keyof Keys>(keys: K[]) {
+      return super.omit(keys as string[]) as Omit<
+        PersistentProps & { [P in keyof Keys]: Keys[P] extends KeyType.uuid ? string : number },
+        K & (keyof PersistentProps | keyof Keys)
+      >;
     }
 
     assign<M extends ModelClass>(this: M, props: Partial<PersistentProps>) {

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -1992,6 +1992,69 @@ describe('Model', () => {
     });
   });
 
+  describe('serialization', () => {
+    const buildKlass = () => {
+      storage = {};
+      return Model({
+        tableName,
+        init: (props: { foo: string; bar: number }) => props,
+        connector: connector(),
+      });
+    };
+
+    it('toJSON returns the full attributes', async () => {
+      const Klass = buildKlass();
+      const r = await Klass.create({ foo: 'x', bar: 42 });
+      const json = r.toJSON();
+      expect(json).toMatchObject({ foo: 'x', bar: 42 });
+      expect(json.id).toBe(r.attributes().id);
+      storage = {};
+    });
+
+    it('JSON.stringify uses toJSON', async () => {
+      const Klass = buildKlass();
+      const r = await Klass.create({ foo: 'x', bar: 1 });
+      const parsed = JSON.parse(JSON.stringify(r));
+      expect(parsed).toMatchObject({ foo: 'x', bar: 1 });
+      storage = {};
+    });
+
+    it('pick returns only requested keys', async () => {
+      const Klass = buildKlass();
+      const r = await Klass.create({ foo: 'x', bar: 7 });
+      expect(r.pick(['foo'])).toEqual({ foo: 'x' });
+      expect(r.pick(['foo', 'bar'])).toEqual({ foo: 'x', bar: 7 });
+      storage = {};
+    });
+
+    it('pick skips missing keys without throwing', async () => {
+      const Klass = buildKlass();
+      const r = await Klass.create({ foo: 'x', bar: 1 });
+      expect(r.pick(['foo', 'nope' as any])).toEqual({ foo: 'x' });
+      storage = {};
+    });
+
+    it('omit removes the requested keys', async () => {
+      const Klass = buildKlass();
+      const r = await Klass.create({ foo: 'x', bar: 7 });
+      const result = r.omit(['bar']);
+      expect(result).not.toHaveProperty('bar');
+      expect(result.foo).toBe('x');
+      expect((result as any).id).toBe(r.attributes().id);
+      storage = {};
+    });
+
+    it('pick and omit reflect in-memory changes', async () => {
+      const Klass = buildKlass();
+      const r = await Klass.create({ foo: 'x', bar: 1 });
+      r.assign({ foo: 'y' });
+      expect(r.pick(['foo'])).toEqual({ foo: 'y' });
+      const omitted = r.omit(['bar', 'id' as any, 'createdAt' as any, 'updatedAt' as any]);
+      expect(omitted).toEqual({ foo: 'y' });
+      storage = {};
+    });
+  });
+
   // describe('.order', () => {
   //   let Klass: typeof Model;
   //   let order: Partial<Order<any>>[] = Faker.order;


### PR DESCRIPTION
## Summary

Adds three instance serialization helpers:

- **`toJSON()`** — returns `attributes()`, making instances work with `JSON.stringify` out of the box.
- **`pick(keys)`** — returns a subset of attributes. Missing keys are skipped (no throw).
- **`omit(keys)`** — returns attributes with the listed keys removed.

```ts
const post = await Post.create({ title: 'Hello', body: 'World', authorId: 1 });

JSON.stringify(post);         // '{"title":"Hello","body":"World","authorId":1,"id":1,...}'
post.pick(['title']);         // { title: 'Hello' }
post.omit(['authorId', 'id']);// { title: 'Hello', body: 'World' }
```

Factory subclass adds typed overrides using `Pick` / `Omit` on the combined `PersistentProps + Keys` shape, so `pick`/`omit` return type narrows correctly.

Stacks on PR 17 (soft deletes).

## Test plan
- [x] `pnpm typecheck` (3 packages)
- [x] `pnpm --filter @next-model/core test` — 5185 passing
- [x] `pnpm biome check packages/core/src`
- [x] Tests cover: toJSON content, JSON.stringify uses toJSON, pick happy path, pick skips missing keys, omit removes listed keys, pick/omit reflect in-memory changes