### PR TITLE
PR 19: Polymorphic associations

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -20,6 +20,9 @@ import { singularize } from './util';
 export type AssociationOptions = {
   foreignKey?: string;
   primaryKey?: string;
+  polymorphic?: string;
+  typeKey?: string;
+  typeValue?: string;
 };
 
 export type HasManyThroughOptions = {
@@ -465,11 +468,20 @@ export class ModelClass {
     Related: Related,
     options: AssociationOptions = {},
   ): Promise<InstanceType<Related> | undefined> {
-    const fk = options.foreignKey ?? `${singularize(Related.tableName)}Id`;
+    const poly = options.polymorphic;
+    const fk = options.foreignKey ?? (poly ? `${poly}Id` : `${singularize(Related.tableName)}Id`);
     const pk = options.primaryKey ?? Object.keys(Related.keys)[0] ?? 'id';
-    const fkValue = (this.attributes() as Dict<any>)[fk];
+    const attrs = this.attributes() as Dict<any>;
+    const fkValue = attrs[fk];
     if (fkValue === undefined || fkValue === null) {
       return Promise.resolve(undefined);
+    }
+    if (poly) {
+      const typeKey = options.typeKey ?? `${poly}Type`;
+      const expectedType = options.typeValue ?? Related.tableName;
+      if (attrs[typeKey] !== expectedType) {
+        return Promise.resolve(undefined);
+      }
     }
     return Related.findBy({ [pk]: fkValue }) as Promise<InstanceType<Related> | undefined>;
   }
@@ -480,10 +492,16 @@ export class ModelClass {
     options: AssociationOptions = {},
   ): Related {
     const selfModel = this.constructor as typeof ModelClass;
-    const fk = options.foreignKey ?? `${singularize(selfModel.tableName)}Id`;
+    const poly = options.polymorphic;
+    const fk = options.foreignKey ?? (poly ? `${poly}Id` : `${singularize(selfModel.tableName)}Id`);
     const pk = options.primaryKey ?? Object.keys(selfModel.keys)[0] ?? 'id';
     const pkValue = (this as any)[pk];
-    return Related.filterBy({ [fk]: pkValue }) as Related;
+    const filter: Dict<any> = { [fk]: pkValue };
+    if (poly) {
+      const typeKey = options.typeKey ?? `${poly}Type`;
+      filter[typeKey] = options.typeValue ?? selfModel.tableName;
+    }
+    return Related.filterBy(filter) as Related;
   }
 
   hasOne<Related extends typeof ModelClass>(
@@ -492,13 +510,19 @@ export class ModelClass {
     options: AssociationOptions = {},
   ): Promise<InstanceType<Related> | undefined> {
     const selfModel = this.constructor as typeof ModelClass;
-    const fk = options.foreignKey ?? `${singularize(selfModel.tableName)}Id`;
+    const poly = options.polymorphic;
+    const fk = options.foreignKey ?? (poly ? `${poly}Id` : `${singularize(selfModel.tableName)}Id`);
     const pk = options.primaryKey ?? Object.keys(selfModel.keys)[0] ?? 'id';
     const pkValue = (this as any)[pk];
     if (pkValue === undefined || pkValue === null) {
       return Promise.resolve(undefined);
     }
-    return Related.findBy({ [fk]: pkValue }) as Promise<InstanceType<Related> | undefined>;
+    const filter: Dict<any> = { [fk]: pkValue };
+    if (poly) {
+      const typeKey = options.typeKey ?? `${poly}Type`;
+      filter[typeKey] = options.typeValue ?? selfModel.tableName;
+    }
+    return Related.findBy(filter) as Promise<InstanceType<Related> | undefined>;
   }
 
   hasManyThrough<Target extends typeof ModelClass, Through extends typeof ModelClass>(

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -1694,6 +1694,146 @@ describe('Model', () => {
         expect(profile?.attributes().bio).toBe('hi');
       });
     });
+
+    describe('polymorphic', () => {
+      it('belongsTo resolves by {name}Id + {name}Type matching target tableName', async () => {
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { title: string }) => props,
+          connector: assocConnector(),
+        });
+        const PhotoKlass = Model({
+          tableName: 'photos',
+          init: (props: { url: string }) => props,
+          connector: assocConnector(),
+        });
+        const CommentKlass = Model({
+          tableName: 'comments',
+          init: (props: { body: string; commentableId: number; commentableType: string }) => props,
+          connector: assocConnector(),
+        });
+        const post = await PostKlass.create({ title: 'Hello' });
+        const photo = await PhotoKlass.create({ url: '/a.jpg' });
+        const c1 = await CommentKlass.create({
+          body: 'on post',
+          commentableId: post.id,
+          commentableType: 'posts',
+        });
+        const c2 = await CommentKlass.create({
+          body: 'on photo',
+          commentableId: photo.id,
+          commentableType: 'photos',
+        });
+        const resolvedPost = await c1.belongsTo(PostKlass, { polymorphic: 'commentable' });
+        const resolvedPhoto = await c2.belongsTo(PhotoKlass, { polymorphic: 'commentable' });
+        expect(resolvedPost?.attributes().title).toBe('Hello');
+        expect(resolvedPhoto?.attributes().url).toBe('/a.jpg');
+      });
+
+      it('belongsTo returns undefined when type does not match target tableName', async () => {
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { title: string }) => props,
+          connector: assocConnector(),
+        });
+        const PhotoKlass = Model({
+          tableName: 'photos',
+          init: (props: { url: string }) => props,
+          connector: assocConnector(),
+        });
+        const CommentKlass = Model({
+          tableName: 'comments',
+          init: (props: { body: string; commentableId: number; commentableType: string }) => props,
+          connector: assocConnector(),
+        });
+        await PostKlass.create({ title: 'Hello' });
+        const photo = await PhotoKlass.create({ url: '/a.jpg' });
+        const c = await CommentKlass.create({
+          body: 'on photo',
+          commentableId: photo.id,
+          commentableType: 'photos',
+        });
+        const resolved = await c.belongsTo(PostKlass, { polymorphic: 'commentable' });
+        expect(resolved).toBeUndefined();
+      });
+
+      it('hasMany scopes by both id and type', async () => {
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { title: string }) => props,
+          connector: assocConnector(),
+        });
+        const CommentKlass = Model({
+          tableName: 'comments',
+          init: (props: { body: string; commentableId: number; commentableType: string }) => props,
+          connector: assocConnector(),
+        });
+        const post1 = await PostKlass.create({ title: 'One' });
+        const post2 = await PostKlass.create({ title: 'Two' });
+        await CommentKlass.create({
+          body: 'a',
+          commentableId: post1.id,
+          commentableType: 'posts',
+        });
+        await CommentKlass.create({
+          body: 'b',
+          commentableId: post1.id,
+          commentableType: 'photos',
+        });
+        await CommentKlass.create({
+          body: 'c',
+          commentableId: post2.id,
+          commentableType: 'posts',
+        });
+        const comments = await post1.hasMany(CommentKlass, { polymorphic: 'commentable' }).all();
+        expect(comments.map((c) => c.attributes().body)).toEqual(['a']);
+      });
+
+      it('honours explicit typeValue override', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const CommentKlass = Model({
+          tableName: 'comments',
+          init: (props: { body: string; commentableId: number; commentableType: string }) => props,
+          connector: assocConnector(),
+        });
+        const user = await UserKlass.create({ name: 'Alice' });
+        await CommentKlass.create({
+          body: 'hi',
+          commentableId: user.id,
+          commentableType: 'User',
+        });
+        const comments = await user
+          .hasMany(CommentKlass, { polymorphic: 'commentable', typeValue: 'User' })
+          .all();
+        expect(comments).toHaveLength(1);
+      });
+
+      it('supports typeKey override', async () => {
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { title: string }) => props,
+          connector: assocConnector(),
+        });
+        const CommentKlass = Model({
+          tableName: 'comments',
+          init: (props: { body: string; targetId: number; targetKind: string }) => props,
+          connector: assocConnector(),
+        });
+        const post = await PostKlass.create({ title: 'P' });
+        await CommentKlass.create({ body: 'x', targetId: post.id, targetKind: 'posts' });
+        const c = await CommentKlass.first();
+        const resolved = await c?.belongsTo(PostKlass, {
+          foreignKey: 'targetId',
+          typeKey: 'targetKind',
+          polymorphic: 'target',
+        });
+        expect(resolved?.attributes().title).toBe('P');
+      });
+    });
   });
 
   describe('scopes', () => {


### PR DESCRIPTION
## Summary

Extends `belongsTo`, `hasMany`, and `hasOne` with an optional `polymorphic` option for records that can belong to multiple parent types, discriminated by a `{name}Type` column.

```ts
const Comment = Model({
  tableName: 'comments',
  init: (props: {
    body: string;
    commentableId: number;
    commentableType: string;
  }) => props,
});

// comment.commentableId + commentableType determine the parent
const post = await comment.belongsTo(Post, { polymorphic: 'commentable' });
// resolves only if commentableType === 'posts' (Post.tableName)

// From the parent side, scoped by both id and type
const comments = await post.hasMany(Comment, { polymorphic: 'commentable' });
```

Defaults when `polymorphic: 'commentable'`:
- `foreignKey = 'commentableId'`
- `typeKey = 'commentableType'`
- `typeValue = <counterpart model>.tableName` (override via `typeValue`)

All three options are individually overridable.

Stacks on PR 18 (serialization).

## Test plan
- [x] `pnpm typecheck` (3 packages)
- [x] `pnpm --filter @next-model/core test` — 5190 passing
- [x] `pnpm biome check packages/core/src`
- [x] Tests cover: belongsTo type-match, belongsTo type-mismatch returns undefined, hasMany scopes by id+type, typeValue override, typeKey override