### PR TITLE
PR 20: Connector sort fix + reverse() / unscoped()

### DIFF
--- a/packages/core/src/MemoryConnector.ts
+++ b/packages/core/src/MemoryConnector.ts
@@ -44,13 +44,6 @@ export class MemoryConnector implements Connector {
     order = [],
   }: Scope): Promise<Dict<any>[]> {
     let items = await filterList(this.collection(tableName), filter);
-    if (skip && limit) {
-      items = items.slice(skip, skip + limit);
-    } else if (skip) {
-      items = items.slice(skip);
-    } else if (limit) {
-      items = items.slice(0, limit);
-    }
 
     for (let orderIndex = order.length - 1; orderIndex >= 0; orderIndex -= 1) {
       const key = order[orderIndex].key;
@@ -79,6 +72,14 @@ export class MemoryConnector implements Connector {
         }
         return 0;
       });
+    }
+
+    if (skip && limit) {
+      items = items.slice(skip, skip + limit);
+    } else if (skip) {
+      items = items.slice(skip);
+    } else if (limit) {
+      items = items.slice(0, limit);
     }
 
     return items;

--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -11,6 +11,7 @@ import {
   type OrderColumn,
   type Schema,
   type Scope,
+  SortDirection,
   type Validator,
 } from './types';
 
@@ -159,6 +160,31 @@ export class ModelClass {
     } as M;
   }
 
+  static reverse<M extends typeof ModelClass>(this: M) {
+    const primaryKey = Object.keys(this.keys)[0] ?? 'id';
+    const existing = this.order.length > 0 ? this.order : [{ key: primaryKey }];
+    const flipped = existing.map((col) => ({
+      key: col.key,
+      dir:
+        (col.dir ?? SortDirection.Asc) === SortDirection.Asc
+          ? SortDirection.Desc
+          : SortDirection.Asc,
+    }));
+    return class extends (this as typeof ModelClass) {
+      static order = flipped;
+    } as M;
+  }
+
+  static unscoped<M extends typeof ModelClass>(this: M) {
+    return class extends (this as typeof ModelClass) {
+      static filter = undefined;
+      static limit = undefined;
+      static skip = undefined;
+      static order: OrderColumn<any>[] = [];
+      static softDelete: 'active' | 'only' | false = false;
+    } as M;
+  }
+
   static withDiscarded<M extends typeof ModelClass>(this: M) {
     return class extends (this as typeof ModelClass) {
       static softDelete: 'active' | 'only' | false = false;
@@ -226,10 +252,7 @@ export class ModelClass {
   }
 
   static async last<M extends typeof ModelClass>(this: M) {
-    const primaryKey = Object.keys(this.keys)[0] ?? 'id';
-    const scoped = this.order.length > 0 ? this : (this.orderBy({ key: primaryKey }) as M);
-    const items = await scoped.all<M>();
-    return items.pop();
+    return (this.reverse() as M).first<M>();
   }
 
   static async ids<M extends typeof ModelClass>(this: M) {

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -2195,6 +2195,91 @@ describe('Model', () => {
     });
   });
 
+  describe('.reverse', () => {
+    const buildKlass = () => {
+      storage = {};
+      return Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+      });
+    };
+
+    it('flips primary-key order when no order is set', async () => {
+      const Klass = buildKlass();
+      await Klass.create({ foo: 'a' });
+      await Klass.create({ foo: 'b' });
+      await Klass.create({ foo: 'c' });
+      const reversed = await Klass.reverse().all();
+      expect(reversed.map((r) => r.attributes().foo)).toEqual(['c', 'b', 'a']);
+      storage = {};
+    });
+
+    it('reverses each column in an existing order', async () => {
+      const Klass = buildKlass();
+      await Klass.create({ foo: 'a' });
+      await Klass.create({ foo: 'c' });
+      await Klass.create({ foo: 'b' });
+      const ordered = await Klass.orderBy({ key: 'foo' as any })
+        .reverse()
+        .all();
+      expect(ordered.map((r) => r.attributes().foo)).toEqual(['c', 'b', 'a']);
+      storage = {};
+    });
+
+    it('composes with limitBy (tests sort-before-slice)', async () => {
+      const Klass = buildKlass();
+      await Klass.create({ foo: 'a' });
+      await Klass.create({ foo: 'b' });
+      await Klass.create({ foo: 'c' });
+      const top = await Klass.orderBy({ key: 'foo' as any })
+        .reverse()
+        .limitBy(1)
+        .all();
+      expect(top).toHaveLength(1);
+      expect(top[0].attributes().foo).toBe('c');
+      storage = {};
+    });
+  });
+
+  describe('.unscoped', () => {
+    it('removes filter, limit, skip, and order', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+        filter: { foo: 'x' },
+        limit: 1,
+      });
+      await Klass.create({ foo: 'x' });
+      await Klass.create({ foo: 'y' });
+      await Klass.create({ foo: 'z' });
+      expect(await Klass.count()).toBe(1);
+      expect(await Klass.unscoped().count()).toBe(3);
+      storage = {};
+    });
+
+    it('removes the soft-delete scope', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { title: string; discardedAt?: Date | null }) => ({
+          discardedAt: null,
+          ...props,
+        }),
+        connector: connector(),
+        softDelete: true,
+      });
+      const a = await Klass.create({ title: 'A' });
+      await Klass.create({ title: 'B' });
+      await a.discard();
+      expect(await Klass.count()).toBe(1);
+      expect(await Klass.unscoped().count()).toBe(2);
+      storage = {};
+    });
+  });
+
   // describe('.order', () => {
   //   let Klass: typeof Model;
   //   let order: Partial<Order<any>>[] = Faker.order;


### PR DESCRIPTION
## Summary

Three related changes to query ordering:

1. **Connector correctness** — `MemoryConnector.items` now sorts *before* slicing. The previous order (slice → sort) meant `.orderBy(x).limitBy(n)` could return the first n inserted rows instead of the first n in the requested order. No visible test regressions, but `.first()` / `.last()` combined with custom ordering silently returned wrong rows.
2. **`reverse()`** — chainable that flips every column in the current order. Falls back to primary-key asc → desc when no order is set. Used internally by `last()`.
3. **`unscoped()`** — strips filter, limit, skip, order, and the soft-delete scope in one call. Useful when you need to bypass accumulated scope constraints (including `softDelete: true`).

```ts
const newest = await Post.orderBy({ key: 'createdAt' }).reverse().first();
const everything = await Post.unscoped().count();
```

Also simplified `last()` to `reverse().first()` now that slice-after-sort is fixed.

Stacks on PR 19 (polymorphic associations).

## Test plan
- [x] `pnpm typecheck` (3 packages)
- [x] `pnpm --filter @next-model/core test` — 5195 passing
- [x] `pnpm biome check packages/core/src`
- [x] Tests cover: reverse with/without pre-existing order, reverse + limitBy exercises sort-before-slice, unscoped strips filter+limit, unscoped strips soft-delete scope