### PR TITLE
PR 21: Dynamic event subscriptions (on)

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -185,6 +185,16 @@ export class ModelClass {
     } as M;
   }
 
+  static on(event: keyof Callbacks<any>, handler: Callback<any>): () => void {
+    if (!this.callbacks[event]) this.callbacks[event] = [];
+    const list = this.callbacks[event] as Callback<any>[];
+    list.push(handler);
+    return () => {
+      const idx = list.indexOf(handler);
+      if (idx >= 0) list.splice(idx, 1);
+    };
+  }
+
   static withDiscarded<M extends typeof ModelClass>(this: M) {
     return class extends (this as typeof ModelClass) {
       static softDelete: 'active' | 'only' | false = false;
@@ -811,6 +821,15 @@ export function Model<
       >,
     ) {
       return super.orFilterBy(filter) as M;
+    }
+
+    static on(
+      event: keyof Callbacks<any>,
+      handler: Callback<
+        PersistentProps & { [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }
+      >,
+    ): () => void {
+      return super.on(event, handler as Callback<any>);
     }
 
     static async select(...keys: [keyof Keys | keyof PersistentProps][]) {

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -2242,6 +2242,125 @@ describe('Model', () => {
     });
   });
 
+  describe('.on', () => {
+    it('fires the registered handler for the given lifecycle event', async () => {
+      storage = {};
+      const seen: string[] = [];
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+      });
+      Klass.on('afterCreate', (instance) => {
+        seen.push(`create:${instance.foo}`);
+      });
+      await Klass.create({ foo: 'a' });
+      expect(seen).toEqual(['create:a']);
+      storage = {};
+    });
+
+    it('returns an unsubscribe function that removes the handler', async () => {
+      storage = {};
+      let calls = 0;
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+      });
+      const unsubscribe = Klass.on('afterSave', () => {
+        calls++;
+      });
+      await Klass.create({ foo: 'a' });
+      unsubscribe();
+      await Klass.create({ foo: 'b' });
+      expect(calls).toBe(1);
+      storage = {};
+    });
+
+    it('runs multiple subscribers for the same event in registration order', async () => {
+      storage = {};
+      const order: string[] = [];
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+      });
+      Klass.on('afterSave', () => void order.push('first'));
+      Klass.on('afterSave', () => void order.push('second'));
+      await Klass.create({ foo: 'a' });
+      expect(order).toEqual(['first', 'second']);
+      storage = {};
+    });
+
+    it('composes with callbacks declared in the factory config', async () => {
+      storage = {};
+      const order: string[] = [];
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+        callbacks: {
+          afterSave: [() => void order.push('config')],
+        },
+      });
+      Klass.on('afterSave', () => void order.push('dynamic'));
+      await Klass.create({ foo: 'a' });
+      expect(order).toEqual(['config', 'dynamic']);
+      storage = {};
+    });
+
+    it('supports async handlers', async () => {
+      storage = {};
+      const order: string[] = [];
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+      });
+      Klass.on('beforeSave', async () => {
+        await Promise.resolve();
+        order.push('before');
+      });
+      Klass.on('afterSave', () => void order.push('after'));
+      await Klass.create({ foo: 'a' });
+      expect(order).toEqual(['before', 'after']);
+      storage = {};
+    });
+
+    it('fires afterDelete when an instance is deleted', async () => {
+      storage = {};
+      const seen: string[] = [];
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+      });
+      const instance = await Klass.create({ foo: 'gone' });
+      Klass.on('afterDelete', (i) => void seen.push(`delete:${i.foo}`));
+      await instance.delete();
+      expect(seen).toEqual(['delete:gone']);
+      storage = {};
+    });
+
+    it('unsubscribe is idempotent', async () => {
+      storage = {};
+      let calls = 0;
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+      });
+      const unsubscribe = Klass.on('afterSave', () => {
+        calls++;
+      });
+      unsubscribe();
+      unsubscribe();
+      await Klass.create({ foo: 'a' });
+      expect(calls).toBe(0);
+      storage = {};
+    });
+  });
+
   describe('.unscoped', () => {
     it('removes filter, limit, skip, and order', async () => {
       storage = {};


### PR DESCRIPTION
## Summary
- Adds `Model.on(event, handler)` static that returns an unsubscribe function, letting external code register lifecycle callbacks without touching the factory config
- Composes cleanly with factory-declared `callbacks`: dynamic subscribers fire after config ones in registration order
- Factory override preserves instance typing for the handler argument

## Rationale
Lifecycle callbacks declared in the factory config are fine for intrinsic behavior, but cross-cutting concerns (audit logs, cache invalidation, event forwarders) don't belong in the model definition. `Model.on` gives those a clean extension point and a disposer for teardown in tests or hot-reload.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm --filter '@next-model/core' test -- --run` (5202 tests pass; 7 new for `.on`)
- [x] `pnpm biome check packages/core/src`