### PR TITLE
PR 24: Post-save change tracking (savedChanges, wasChanged)

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -460,6 +460,7 @@ export class ModelClass {
 
   persistentProps: Dict<any>;
   changedProps: Dict<any> = {};
+  lastSavedChanges: Dict<{ from: any; to: any }> = {};
   keys: Dict<any> | undefined;
 
   constructor(props: Dict<any>, keys?: Dict<any>) {
@@ -542,6 +543,22 @@ export class ModelClass {
       result[key] = { from: this.persistentProps[key], to: this.changedProps[key] };
     }
     return result;
+  }
+
+  savedChanges(): Dict<{ from: any; to: any }> {
+    return { ...this.lastSavedChanges };
+  }
+
+  savedChangeBy(key: string): { from: any; to: any } | undefined {
+    return this.lastSavedChanges[key];
+  }
+
+  wasChanged(): boolean {
+    return Object.keys(this.lastSavedChanges).length > 0;
+  }
+
+  wasChangedBy(key: string): boolean {
+    return key in this.lastSavedChanges;
   }
 
   revertChange<M extends ModelClass>(this: M, key: string) {
@@ -686,11 +703,16 @@ export class ModelClass {
     await this.runCallbacks('beforeSave');
     await this.runCallbacks(isInsert ? 'beforeCreate' : 'beforeUpdate');
 
+    const snapshot: Dict<{ from: any; to: any }> = {};
+
     if (this.keys) {
       const changedKeys = Object.keys(this.changedProps);
       if (changedKeys.length > 0) {
         if (model.timestamps) {
           this.changedProps.updatedAt = now;
+        }
+        for (const key in this.changedProps) {
+          snapshot[key] = { from: this.persistentProps[key], to: this.changedProps[key] };
         }
         const items = await model.connector.updateAll(this.itemScope(), this.changedProps);
         const item = items.pop();
@@ -719,12 +741,20 @@ export class ModelClass {
           this.keys[key] = item[key];
           delete item[key];
         }
+        for (const key in item) {
+          snapshot[key] = { from: undefined, to: item[key] };
+        }
+        for (const key in this.keys) {
+          snapshot[key] = { from: undefined, to: this.keys[key] };
+        }
         this.persistentProps = item;
         this.changedProps = {};
       } else {
         throw new PersistenceError('Failed to insert item');
       }
     }
+
+    this.lastSavedChanges = snapshot;
 
     await this.runCallbacks(isInsert ? 'afterCreate' : 'afterUpdate');
     await this.runCallbacks('afterSave');

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -600,6 +600,111 @@ describe('Model', () => {
     });
   });
 
+  describe('savedChanges / wasChanged', () => {
+    it('captures inserted attributes with from: undefined after create', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+        timestamps: false,
+      });
+      const record = await Klass.create({ foo: 'hello' });
+      expect(record.wasChanged()).toBe(true);
+      expect(record.wasChangedBy('foo')).toBe(true);
+      expect(record.wasChangedBy('id')).toBe(true);
+      expect(record.savedChangeBy('foo')).toEqual({ from: undefined, to: 'hello' });
+      expect(record.savedChanges().foo).toEqual({ from: undefined, to: 'hello' });
+      storage = {};
+    });
+
+    it('captures only the updated attributes with their prior values', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string; bar: string }) => props,
+        connector: connector(),
+        timestamps: false,
+      });
+      const record = await Klass.create({ foo: 'a', bar: 'b' });
+      record.assign({ foo: 'A' });
+      await record.save();
+      expect(record.wasChangedBy('foo')).toBe(true);
+      expect(record.wasChangedBy('bar')).toBe(false);
+      expect(record.savedChangeBy('foo')).toEqual({ from: 'a', to: 'A' });
+      expect(record.savedChangeBy('bar')).toBeUndefined();
+      storage = {};
+    });
+
+    it('clears pending changes (#changes) while keeping savedChanges', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+        timestamps: false,
+      });
+      const record = await Klass.create({ foo: 'a' });
+      record.assign({ foo: 'b' });
+      await record.save();
+      expect(record.isChanged()).toBe(false);
+      expect(record.changes()).toEqual({});
+      expect(record.savedChanges().foo).toEqual({ from: 'a', to: 'b' });
+      storage = {};
+    });
+
+    it('exposes savedChanges from an afterUpdate callback', async () => {
+      storage = {};
+      let seen: any;
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+        timestamps: false,
+      });
+      Klass.on('afterUpdate', (instance) => {
+        seen = (instance as any).savedChanges();
+      });
+      const record = await Klass.create({ foo: 'a' });
+      record.assign({ foo: 'b' });
+      await record.save();
+      expect(seen.foo).toEqual({ from: 'a', to: 'b' });
+      storage = {};
+    });
+
+    it('replaces the prior snapshot on each subsequent save', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+        timestamps: false,
+      });
+      const record = await Klass.create({ foo: 'a' });
+      record.assign({ foo: 'b' });
+      await record.save();
+      record.assign({ foo: 'c' });
+      await record.save();
+      expect(record.savedChangeBy('foo')).toEqual({ from: 'b', to: 'c' });
+      storage = {};
+    });
+
+    it('returns wasChanged() false when save is a no-op (no pending changes)', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { foo: string }) => props,
+        connector: connector(),
+        timestamps: false,
+      });
+      const record = await Klass.create({ foo: 'a' });
+      await record.save();
+      expect(record.wasChanged()).toBe(false);
+      expect(record.savedChanges()).toEqual({});
+      storage = {};
+    });
+  });
+
   describe('timestamps', () => {
     it('sets createdAt and updatedAt on insert by default', async () => {
       storage = {};


### PR DESCRIPTION
## Summary
- Adds instance methods `savedChanges()`, `savedChangeBy(key)`, `wasChanged()`, `wasChangedBy(key)` — snapshot of what the *last* save persisted
- `save()` captures `{ from, to }` pairs into `lastSavedChanges` before clearing `changedProps`
- Inserts record every attribute with `from: undefined`; updates record only keys that actually changed
- A no-op save (no pending changes) clears the snapshot

## Rationale
Complements the pending-state API (`isChanged`, `changes`, `revertChange`) with a completed-state view. Needed for audit trails, cache invalidation, and conditional event emission from `afterSave` / `afterUpdate` handlers (including dynamic `Model.on` subscribers added in PR 21).

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm --filter '@next-model/core' test -- --run` (5221 tests pass; 6 new)
- [x] `pnpm biome check packages/core/src`