### PR TITLE
PR 25: Group-by helpers (countBy, groupBy)

### DIFF
--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -366,6 +366,33 @@ export class ModelClass {
     return await this.connector.count(this.modelScope());
   }
 
+  static async countBy(key: string): Promise<Map<any, number>> {
+    const values = await this.pluck(key);
+    const result = new Map<any, number>();
+    for (const value of values) {
+      result.set(value, (result.get(value) ?? 0) + 1);
+    }
+    return result;
+  }
+
+  static async groupBy<M extends typeof ModelClass>(
+    this: M,
+    key: string,
+  ): Promise<Map<any, InstanceType<M>[]>> {
+    const items = await this.all<M>();
+    const result = new Map<any, InstanceType<M>[]>();
+    for (const item of items) {
+      const bucket = (item.attributes() as Dict<any>)[key];
+      const list = result.get(bucket);
+      if (list) {
+        list.push(item);
+      } else {
+        result.set(bucket, [item]);
+      }
+    }
+    return result;
+  }
+
   static async aggregate<M extends typeof ModelClass>(
     this: M,
     kind: AggregateKind,
@@ -1000,6 +1027,23 @@ export function Model<
 
     static async count<M extends typeof ModelClass>(this: M) {
       return await super.count();
+    }
+
+    static async countBy(key: keyof Keys | keyof PersistentProps) {
+      return super.countBy(key as string);
+    }
+
+    static async groupBy<M extends typeof ModelClass>(
+      this: M,
+      key: keyof Keys | keyof PersistentProps,
+    ) {
+      const result = await super.groupBy(key as string);
+      return result as Map<
+        any,
+        (InstanceType<M> &
+          PersistentProps &
+          Readonly<{ [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }>)[]
+      >;
     }
 
     static async sum<M extends typeof ModelClass>(this: M, key: keyof PersistentProps) {

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -2106,6 +2106,118 @@ describe('Model', () => {
     });
   });
 
+  describe('.countBy', () => {
+    it('counts rows per unique key value', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { tag: string }) => props,
+        connector: connector(),
+      });
+      for (const tag of ['red', 'blue', 'red', 'green', 'blue', 'red']) {
+        await Klass.create({ tag });
+      }
+      const result = await Klass.countBy('tag');
+      expect(result.get('red')).toBe(3);
+      expect(result.get('blue')).toBe(2);
+      expect(result.get('green')).toBe(1);
+      expect(result.size).toBe(3);
+      storage = {};
+    });
+
+    it('respects the current filter scope', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { tag: string; active: boolean }) => props,
+        connector: connector(),
+      });
+      await Klass.create({ tag: 'red', active: true });
+      await Klass.create({ tag: 'red', active: false });
+      await Klass.create({ tag: 'blue', active: true });
+      const result = await Klass.filterBy({ active: true }).countBy('tag');
+      expect(result.get('red')).toBe(1);
+      expect(result.get('blue')).toBe(1);
+      storage = {};
+    });
+
+    it('returns an empty map when no rows match', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { tag: string }) => props,
+        connector: connector(),
+      });
+      const result = await Klass.countBy('tag');
+      expect(result.size).toBe(0);
+      storage = {};
+    });
+
+    it('counts null as its own bucket', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { tag: string | null }) => props,
+        connector: connector(),
+      });
+      await Klass.create({ tag: 'red' });
+      await Klass.create({ tag: null });
+      await Klass.create({ tag: null });
+      const result = await Klass.countBy('tag');
+      expect(result.get('red')).toBe(1);
+      expect(result.get(null)).toBe(2);
+      storage = {};
+    });
+  });
+
+  describe('.groupBy', () => {
+    it('groups instances into buckets keyed by the given attribute', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { tag: string; title: string }) => props,
+        connector: connector(),
+        order: { key: 'title' },
+      });
+      await Klass.create({ tag: 'red', title: 'a' });
+      await Klass.create({ tag: 'blue', title: 'b' });
+      await Klass.create({ tag: 'red', title: 'c' });
+      const result = await Klass.groupBy('tag');
+      expect(result.get('red')?.map((i) => i.title)).toEqual(['a', 'c']);
+      expect(result.get('blue')?.map((i) => i.title)).toEqual(['b']);
+      expect(result.size).toBe(2);
+      storage = {};
+    });
+
+    it('preserves the order of insertion within each bucket', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { tag: string; rank: number }) => props,
+        connector: connector(),
+        order: { key: 'rank' },
+      });
+      await Klass.create({ tag: 'a', rank: 3 });
+      await Klass.create({ tag: 'a', rank: 1 });
+      await Klass.create({ tag: 'a', rank: 2 });
+      const result = await Klass.groupBy('tag');
+      expect(result.get('a')?.map((i) => i.rank)).toEqual([1, 2, 3]);
+      storage = {};
+    });
+
+    it('returns an empty map when no rows match', async () => {
+      storage = {};
+      const Klass = Model({
+        tableName,
+        init: (props: { tag: string }) => props,
+        connector: connector(),
+      });
+      const result = await Klass.groupBy('tag');
+      expect(result.size).toBe(0);
+      storage = {};
+    });
+  });
+
   describe('.inBatchesOf', () => {
     it('yields batches of the requested size in order', async () => {
       storage = {};


### PR DESCRIPTION
## Summary
- `Model.countBy(key)` — returns `Map<value, number>` with row counts per unique key value
- `Model.groupBy(key)` — returns `Map<value, InstanceType[]>` bucketing full instances
- Both respect the current filter/soft-delete scope
- `null` is treated as its own bucket in both

## Rationale
Group aggregation is a common dashboard/analytics need. `countBy` is much cheaper than `groupBy` since it only needs `pluck` (single-column select), while `groupBy` hydrates full instances for cases where the caller wants to iterate the grouped rows.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm --filter '@next-model/core' test -- --run` (5228 tests pass; 7 new)
- [x] `pnpm biome check packages/core/src`