### PR TITLE
PR 27: Backfill vNext section in HISTORY.md

### DIFF
--- a/packages/core/HISTORY.md
+++ b/packages/core/HISTORY.md
@@ -2,6 +2,122 @@
 
 ## vNext
 
+Rolling changelog for the next major release. Items below are appended in the order they ship; this list will be finalized into a version heading when the release is cut.
+
+### Tooling
+
+- Converted to a pnpm monorepo; `@next-model/core` lives under `packages/core` alongside `knex-connector` and `data-api-connector`.
+- Migrated test runner from jest to vitest.
+- Migrated linter/formatter from prettier + eslint to biome.
+- Replaced Travis CI with GitHub Actions (typecheck + lint + tests on every branch/PR).
+
+### Factory & configuration
+
+- New `Model({ tableName, init, ... })` factory returning a subclassable class. Replaces the old `NextModel<Schema>()` decorator/generic form.
+- Factory options: `connector`, `keys`, `filter`, `order`, `limit`, `skip`, `timestamps`, `softDelete`, `validators`, `callbacks`, `scopes`.
+- `KeyType.uuid` and `KeyType.number` primary key generation (auto-assigned on insert).
+- Named scopes declared in `scopes: {...}` installed as typed class methods.
+
+### Query chainables
+
+- `filterBy`, `orFilterBy`, `unfiltered`.
+- `orderBy`, `reorder`, `unordered`, `reverse` (flips current order; falls back to descending primary key).
+- `limitBy`, `unlimited`, `skipBy`, `unskipped`.
+- `unscoped` clears filter, limit, skip, order, and the soft-delete scope in one call.
+
+### Filter operators
+
+- Boolean composition: `$and`, `$or`, `$not`.
+- Set membership: `$in`, `$notIn`.
+- Null checks: `$null`, `$notNull`.
+- Range: `$between`, `$notBetween`.
+- Comparisons: `$gt`, `$gte`, `$lt`, `$lte`.
+- Pattern: `$like`.
+- Lazy filter resolution: `$async` (await a promise that resolves to a filter).
+- Connector-specific raw SQL + bindings: `$raw`.
+- `FilterEngine` extracted from `MemoryConnector` for reuse.
+
+### Fetching
+
+- `all`, `first`, `last` (`last` reuses `reverse()` + `first`).
+- `find(id)` throws `NotFoundError`.
+- `findBy(filter)`, `findOrFail(filter)`, `findOrBuild(filter, props)`, `firstOrCreate(filter, props)`, `updateOrCreate(filter, attrs)`.
+- `exists()` / `exists(filter)`.
+- `ids()`, `pluck(key)`, `pluckUnique(key)`.
+- `paginate(page, perPage = 25)` returning `{ items, total, page, perPage, totalPages, hasNext, hasPrev }`.
+- Async-iterator batch iteration: `inBatchesOf(size)` yields arrays; `findEach(size = 100)` yields individual instances.
+
+### Creating & updating
+
+- `build`, `create`, `createMany`, `buildScoped`, `createScoped`.
+- Instance `save`, `update(attrs)`, `assign(attrs)`, `reload`.
+- `increment(key, by = 1)`, `decrement(key, by = 1)`, `touch()`.
+- Static `updateAll(attrs)` bumping `updatedAt` when timestamps are on.
+
+### Deleting
+
+- Instance `delete()`, static `deleteAll()`.
+
+### Soft deletes
+
+- `softDelete: true` factory flag filters out rows with `discardedAt` by default.
+- Instance `discard()`, `restore()`, `isDiscarded()`.
+- Scope modifiers `withDiscarded()` and `onlyDiscarded()`.
+
+### Dirty tracking
+
+- Pending-state: `isChanged()`, `isChangedBy(key)`, `changes()`, `revertChange(key)`, `revertChanges()`.
+- Post-save snapshot: `savedChanges()`, `savedChangeBy(key)`, `wasChanged()`, `wasChangedBy(key)` — populated before `afterSave`/`afterUpdate` callbacks run.
+
+### Aggregates
+
+- `count`, `sum`, `min`, `max`, `avg` (pushed to the connector via `aggregate(scope, kind, key)`).
+- `countBy(key)` → `Map<value, number>`.
+- `groupBy(key)` → `Map<value, InstanceType[]>`.
+
+### Serialization
+
+- `attributes()`, `toJSON()`, `pick(keys)`, `omit(keys)` with typed overrides in the factory subclass.
+
+### Validators
+
+- Static `validators: Validator[]` array on the factory.
+- Instance `isValid()` short-circuits on the first failing validator.
+- `save()` throws `ValidationError` when any validator returns `false`.
+
+### Lifecycle callbacks
+
+- Factory `callbacks: { beforeSave, afterSave, beforeCreate, afterCreate, beforeUpdate, afterUpdate, beforeDelete, afterDelete }`.
+- Dynamic subscription via `Model.on(event, handler)` returning an unsubscribe function. Composes with factory-declared callbacks (factory fires first, then dynamic subscribers in registration order).
+
+### Timestamps
+
+- Automatic `createdAt` on insert and `updatedAt` on every save, controlled by the `timestamps` factory flag (defaults to `true`). User-supplied values on insert are preserved.
+
+### Associations
+
+- Instance-level helpers: `belongsTo(Related, options?)`, `hasMany(Related, options?)`, `hasOne(Related, options?)`, `hasManyThrough(Target, Through, options?)`.
+- Options: `foreignKey`, `primaryKey`, `throughForeignKey`, `targetForeignKey`, `selfPrimaryKey`, `targetPrimaryKey`.
+- Polymorphic associations via `polymorphic`, `typeKey`, `typeValue`.
+
+### Transactions
+
+- `Model.transaction(fn)` delegates to the connector. `MemoryConnector` snapshots storage + last-ids on entry and restores on throw. Nestable (inner block joins the outer transaction).
+
+### Connector interface
+
+- `query`, `count`, `select`, `updateAll`, `deleteAll`, `batchInsert`, `aggregate(scope, kind, key)`, `execute(query, bindings)`, `transaction`.
+- `MemoryConnector` ships in `@next-model/core`.
+- Sort-before-slice bug in `MemoryConnector` fixed, so `limitBy(1).orderBy(...)` is consistent and `last()` is correct without workarounds.
+
+### Errors
+
+- Typed error subclasses: `NextModelError` (base), `NotFoundError`, `PersistenceError`, `ValidationError`, `FilterError`.
+
+### Docs
+
+- README fully rewritten for the current factory API with sections for every feature above.
+
 ## v1.0.0
 
 Complete rewrite in TypeScript


### PR DESCRIPTION
## Summary

- Populates `packages/core/HISTORY.md` under `## vNext` with a rolling changelog covering every user-visible change shipped across PRs 1–25.
- Sets the pattern for future feature PRs to append their entry to this section until the next major version is cut.

## Sections added

Tooling, Factory & configuration, Query chainables, Filter operators, Fetching, Creating & updating, Deleting, Soft deletes, Dirty tracking, Aggregates, Serialization, Validators, Lifecycle callbacks, Timestamps, Associations, Transactions, Connector interface, Errors, Docs.

## Test plan

- [x] Docs-only change — no code or tests affected.
- [x] `packages/core/HISTORY.md` renders correctly and reflects the current public API.