### PR TITLE
PR 28: Eager loading (preloadBelongsTo, preloadHasMany)

### DIFF
--- a/packages/core/HISTORY.md
+++ b/packages/core/HISTORY.md
@@ -99,6 +99,7 @@ Rolling changelog for the next major release. Items below are appended in the or
 - Instance-level helpers: `belongsTo(Related, options?)`, `hasMany(Related, options?)`, `hasOne(Related, options?)`, `hasManyThrough(Target, Through, options?)`.
 - Options: `foreignKey`, `primaryKey`, `throughForeignKey`, `targetForeignKey`, `selfPrimaryKey`, `targetPrimaryKey`.
 - Polymorphic associations via `polymorphic`, `typeKey`, `typeValue`.
+- Batch preload helpers to avoid N+1 queries: `Related.preloadBelongsTo(records, { foreignKey, primaryKey? })` returns `Map<parentPk, Related>`, `Related.preloadHasMany(records, { foreignKey, primaryKey? })` returns `Map<parentPk, Related[]>` (empty buckets are pre-seeded for every parent).
 
 ### Transactions
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -430,6 +430,30 @@ class Post extends Model({ ... }) {
 
 Override the defaults via `foreignKey`, `primaryKey`, `typeKey`, `typeValue` as needed.
 
+### Eager loading
+
+Instance-level association helpers query lazily, which is fine for a single record but produces N+1 queries when iterating a collection. Use `preloadBelongsTo` / `preloadHasMany` on the related model to batch-load in a single query and look up per record:
+
+```ts
+// belongsTo: one parent per child
+const posts = await Post.all();
+const authorsByKey = await User.preloadBelongsTo(posts, { foreignKey: 'userId' });
+for (const post of posts) {
+  const author = authorsByKey.get(post.userId);
+  // ...
+}
+
+// hasMany: many children per parent
+const users = await User.all();
+const postsByUser = await Post.preloadHasMany(users, { foreignKey: 'userId' });
+for (const user of users) {
+  const posts = postsByUser.get(user.id) ?? [];
+  // ...
+}
+```
+
+Both helpers accept an optional `primaryKey` for non-`id` parent keys. `preloadHasMany` pre-seeds empty buckets for every parent, so `.get(parent.id)` always returns an array.
+
 ## Transactions
 
 ```ts

--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -393,6 +393,55 @@ export class ModelClass {
     return result;
   }
 
+  static async preloadBelongsTo<M extends typeof ModelClass>(
+    this: M,
+    records: any[],
+    options: { foreignKey: string; primaryKey?: string },
+  ): Promise<Map<any, InstanceType<M>>> {
+    const fk = options.foreignKey;
+    const pk = options.primaryKey ?? Object.keys(this.keys)[0] ?? 'id';
+    const ids = new Set<any>();
+    for (const record of records) {
+      const attrs = typeof record?.attributes === 'function' ? record.attributes() : record;
+      const value = attrs?.[fk];
+      if (value !== undefined && value !== null) ids.add(value);
+    }
+    if (ids.size === 0) return new Map();
+    const related = await this.filterBy({ $in: { [pk]: [...ids] } } as Filter<any>).all<M>();
+    const result = new Map<any, InstanceType<M>>();
+    for (const r of related) {
+      const key = (r.attributes() as Dict<any>)[pk];
+      result.set(key, r);
+    }
+    return result;
+  }
+
+  static async preloadHasMany<M extends typeof ModelClass>(
+    this: M,
+    records: any[],
+    options: { foreignKey: string; primaryKey?: string },
+  ): Promise<Map<any, InstanceType<M>[]>> {
+    const fk = options.foreignKey;
+    const pk = options.primaryKey ?? 'id';
+    const ids = new Set<any>();
+    for (const record of records) {
+      const attrs = typeof record?.attributes === 'function' ? record.attributes() : record;
+      const value = attrs?.[pk];
+      if (value !== undefined && value !== null) ids.add(value);
+    }
+    const result = new Map<any, InstanceType<M>[]>();
+    for (const id of ids) result.set(id, []);
+    if (ids.size === 0) return result;
+    const related = await this.filterBy({ $in: { [fk]: [...ids] } } as Filter<any>).all<M>();
+    for (const r of related) {
+      const key = (r.attributes() as Dict<any>)[fk];
+      const list = result.get(key);
+      if (list) list.push(r);
+      else result.set(key, [r]);
+    }
+    return result;
+  }
+
   static async aggregate<M extends typeof ModelClass>(
     this: M,
     kind: AggregateKind,
@@ -1038,6 +1087,34 @@ export function Model<
       key: keyof Keys | keyof PersistentProps,
     ) {
       const result = await super.groupBy(key as string);
+      return result as Map<
+        any,
+        (InstanceType<M> &
+          PersistentProps &
+          Readonly<{ [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }>)[]
+      >;
+    }
+
+    static async preloadBelongsTo<M extends typeof ModelClass>(
+      this: M,
+      records: any[],
+      options: { foreignKey: string; primaryKey?: keyof Keys & string },
+    ) {
+      const result = await super.preloadBelongsTo(records, options);
+      return result as Map<
+        any,
+        InstanceType<M> &
+          PersistentProps &
+          Readonly<{ [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }>
+      >;
+    }
+
+    static async preloadHasMany<M extends typeof ModelClass>(
+      this: M,
+      records: any[],
+      options: { foreignKey: keyof PersistentProps & string; primaryKey?: string },
+    ) {
+      const result = await super.preloadHasMany(records, options);
       return result as Map<
         any,
         (InstanceType<M> &

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -1939,6 +1939,204 @@ describe('Model', () => {
         expect(resolved?.attributes().title).toBe('P');
       });
     });
+
+    describe('.preloadBelongsTo', () => {
+      it('returns a map from parent pk to parent instance, keyed by the child foreignKey value', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { userId: number; title: string }) => props,
+          connector: assocConnector(),
+        });
+        const alice = await UserKlass.create({ name: 'Alice' });
+        const bob = await UserKlass.create({ name: 'Bob' });
+        await PostKlass.create({ userId: alice.id, title: 'A' });
+        await PostKlass.create({ userId: alice.id, title: 'B' });
+        await PostKlass.create({ userId: bob.id, title: 'C' });
+        const posts = await PostKlass.all();
+        const authorsByKey = await UserKlass.preloadBelongsTo(posts, { foreignKey: 'userId' });
+        expect(authorsByKey.size).toBe(2);
+        expect(authorsByKey.get(alice.id)?.attributes().name).toBe('Alice');
+        expect(authorsByKey.get(bob.id)?.attributes().name).toBe('Bob');
+      });
+
+      it('de-duplicates parent lookups to a single query', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { userId: number; title: string }) => props,
+          connector: assocConnector(),
+        });
+        const alice = await UserKlass.create({ name: 'Alice' });
+        for (let i = 0; i < 5; i++) {
+          await PostKlass.create({ userId: alice.id, title: `P${i}` });
+        }
+        const connector = UserKlass.connector as any;
+        const querySpy = vi.spyOn(connector, 'query');
+        const posts = await PostKlass.all();
+        querySpy.mockClear();
+        await UserKlass.preloadBelongsTo(posts, { foreignKey: 'userId' });
+        expect(querySpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('returns an empty map when records list is empty', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const result = await UserKlass.preloadBelongsTo([], { foreignKey: 'userId' });
+        expect(result.size).toBe(0);
+      });
+
+      it('skips null/undefined foreign keys', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { userId: number | null; title: string }) => props,
+          connector: assocConnector(),
+        });
+        const alice = await UserKlass.create({ name: 'Alice' });
+        await PostKlass.create({ userId: alice.id, title: 'A' });
+        await PostKlass.create({ userId: null, title: 'Orphan' });
+        const posts = await PostKlass.all();
+        const authorsByKey = await UserKlass.preloadBelongsTo(posts, { foreignKey: 'userId' });
+        expect(authorsByKey.size).toBe(1);
+        expect(authorsByKey.get(alice.id)?.attributes().name).toBe('Alice');
+      });
+
+      it('supports a custom primaryKey on the parent', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { slug: string; name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { userSlug: string; title: string }) => props,
+          connector: assocConnector(),
+        });
+        await UserKlass.create({ slug: 'alice', name: 'Alice' });
+        await PostKlass.create({ userSlug: 'alice', title: 'A' });
+        const posts = await PostKlass.all();
+        const authorsBySlug = await UserKlass.preloadBelongsTo(posts, {
+          foreignKey: 'userSlug',
+          primaryKey: 'slug',
+        });
+        expect(authorsBySlug.get('alice')?.attributes().name).toBe('Alice');
+      });
+
+      it('accepts plain objects as records', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const alice = await UserKlass.create({ name: 'Alice' });
+        const authorsByKey = await UserKlass.preloadBelongsTo(
+          [{ userId: alice.id }, { userId: alice.id }],
+          { foreignKey: 'userId' },
+        );
+        expect(authorsByKey.get(alice.id)?.attributes().name).toBe('Alice');
+      });
+    });
+
+    describe('.preloadHasMany', () => {
+      it('returns a map from parent pk to child array, including empty buckets', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { userId: number; title: string }) => props,
+          connector: assocConnector(),
+        });
+        const alice = await UserKlass.create({ name: 'Alice' });
+        const bob = await UserKlass.create({ name: 'Bob' });
+        const carol = await UserKlass.create({ name: 'Carol' });
+        await PostKlass.create({ userId: alice.id, title: 'A1' });
+        await PostKlass.create({ userId: alice.id, title: 'A2' });
+        await PostKlass.create({ userId: bob.id, title: 'B1' });
+        const users = await UserKlass.all();
+        const postsByUser = await PostKlass.preloadHasMany(users, { foreignKey: 'userId' });
+        expect(
+          postsByUser
+            .get(alice.id)
+            ?.map((p) => p.attributes().title)
+            .sort(),
+        ).toEqual(['A1', 'A2']);
+        expect(postsByUser.get(bob.id)?.map((p) => p.attributes().title)).toEqual(['B1']);
+        expect(postsByUser.get(carol.id)).toEqual([]);
+      });
+
+      it('de-duplicates child lookups to a single query', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { userId: number; title: string }) => props,
+          connector: assocConnector(),
+        });
+        const alice = await UserKlass.create({ name: 'Alice' });
+        const bob = await UserKlass.create({ name: 'Bob' });
+        await PostKlass.create({ userId: alice.id, title: 'A' });
+        await PostKlass.create({ userId: bob.id, title: 'B' });
+        const connector = PostKlass.connector as any;
+        const querySpy = vi.spyOn(connector, 'query');
+        const users = await UserKlass.all();
+        querySpy.mockClear();
+        await PostKlass.preloadHasMany(users, { foreignKey: 'userId' });
+        expect(querySpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('returns an empty map when parents list is empty', async () => {
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { userId: number; title: string }) => props,
+          connector: assocConnector(),
+        });
+        const result = await PostKlass.preloadHasMany([], { foreignKey: 'userId' });
+        expect(result.size).toBe(0);
+      });
+
+      it('supports a custom primaryKey on the parent', async () => {
+        const UserKlass = Model({
+          tableName: 'users',
+          init: (props: { slug: string; name: string }) => props,
+          connector: assocConnector(),
+        });
+        const PostKlass = Model({
+          tableName: 'posts',
+          init: (props: { userSlug: string; title: string }) => props,
+          connector: assocConnector(),
+        });
+        await UserKlass.create({ slug: 'alice', name: 'Alice' });
+        await PostKlass.create({ userSlug: 'alice', title: 'A' });
+        const users = await UserKlass.all();
+        const postsBySlug = await PostKlass.preloadHasMany(users, {
+          foreignKey: 'userSlug',
+          primaryKey: 'slug',
+        });
+        expect(postsBySlug.get('alice')?.map((p) => p.attributes().title)).toEqual(['A']);
+      });
+    });
   });
 
   describe('scopes', () => {


### PR DESCRIPTION
## Summary

- Adds `preloadBelongsTo(records, { foreignKey, primaryKey? })` and `preloadHasMany(records, { foreignKey, primaryKey? })` static helpers on `ModelClass` that batch-fetch associated records in a single query to avoid N+1 iteration.
- `preloadBelongsTo` returns `Map<parentPk, RelatedInstance>`; `preloadHasMany` returns `Map<parentPk, RelatedInstance[]>` with empty buckets pre-seeded for every parent.
- Null/undefined foreign keys are skipped. Plain-object records are accepted alongside Model instances.
- Factory subclass narrows the Map value type to `InstanceType<M> & PersistentProps & Readonly<Keys>`.

## Usage

```ts
const posts = await Post.all();
const authorsByKey = await User.preloadBelongsTo(posts, { foreignKey: 'userId' });
// authorsByKey.get(post.userId) → User instance

const users = await User.all();
const postsByUser = await Post.preloadHasMany(users, { foreignKey: 'userId' });
// postsByUser.get(user.id) → Post[]
```

## Changes

- `packages/core/src/Model.ts`: new helpers on `ModelClass` + typed overrides in the factory subclass.
- `packages/core/src/__tests__/Model.spec.ts`: 10 new tests covering single-query batching, empty inputs, null FKs, custom primary keys, plain-object records, and empty bucket seeding.
- `packages/core/README.md`: new "Eager loading" subsection under Associations.
- `packages/core/HISTORY.md`: vNext entry under Associations.

## Test plan

- [x] `pnpm vitest run` — 5238 tests pass (10 new).
- [x] `pnpm tsc --noEmit` — clean.
- [x] `pnpm biome check packages/core` — clean.