### PR TITLE
PR 33: Migration dependency graph + parallel apply

### DIFF
--- a/packages/migrations/HISTORY.md
+++ b/packages/migrations/HISTORY.md
@@ -11,6 +11,8 @@ Rolling changelog for the next major release. Items below are appended in the or
 - API: `init()`, `drop()`, `appliedVersions()`, `appliedEntries()`, `pending(migrations)`, `status(migrations)`, `migrate(migrations)`, `up(migration)`, `down(migration)`, `rollback(migrations, steps?)`.
 - Each `up`/`down` runs inside `connector.transaction` so a thrown migration is rolled back atomically and the tracking row is only written after the migration body succeeds.
 - `status` reports both pending migrations and orphan entries (applied versions missing from the provided list); `rollback` throws `MigrationMissingError` if it cannot find a matching definition.
-- Typed error taxonomy: `MigrationError` (base), `MigrationAlreadyAppliedError`, `MigrationNotAppliedError`, `MigrationMissingError`.
+- Typed error taxonomy: `MigrationError` (base), `MigrationAlreadyAppliedError`, `MigrationNotAppliedError`, `MigrationMissingError`, `MigrationParentMissingError`, `MigrationCycleError`.
 - Migrations are ordered by `version` string via `localeCompare`, so zero-padded or ISO-like timestamps sort naturally.
+- Optional dependency graph: migrations may declare `parent?: string[]` to depend on one or more prior versions. When omitted, the previous version in the sorted list is used as the implicit parent; an empty array marks a root node. `Migrator` topologically orders migrations before applying, reports cycles via `MigrationCycleError`, and flags declared parents missing from the provided list via `MigrationParentMissingError`.
+- `migrate(migrations, { parallel: true })` applies independent branches concurrently: each dependency wave is executed via `Promise.all`, so migrations that share no ancestor run side-by-side. Sequential mode remains the default; `rollback` always runs in reverse topological order.
 - Zero runtime dependencies beyond `@next-model/core`. Connector packages are consumed only at test-time.

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -2,10 +2,12 @@ import { type Connector, KeyType } from '@next-model/core';
 
 import {
   MigrationAlreadyAppliedError,
+  MigrationCycleError,
   MigrationMissingError,
   MigrationNotAppliedError,
+  MigrationParentMissingError,
 } from './errors';
-import type { Migration, MigrationStatus, MigratorOptions } from './types';
+import type { MigrateOptions, Migration, MigrationStatus, MigratorOptions } from './types';
 
 const DEFAULT_TABLE_NAME = 'schema_migrations';
 const VERSION_LIMIT = 255;
@@ -64,21 +66,26 @@ export class Migrator {
 
   async pending(migrations: Migration[]): Promise<Migration[]> {
     const applied = new Set(await this.appliedVersions());
-    return sortByVersion(migrations).filter((m) => !applied.has(m.version));
+    return topologicalOrder(migrations).filter((m) => !applied.has(m.version));
   }
 
   async status(migrations: Migration[]): Promise<MigrationStatus[]> {
     const entries = await this.appliedEntries();
     const appliedMap = new Map(entries.map((e) => [e.version, e]));
     const known = new Set(migrations.map((m) => m.version));
+    const ordered = topologicalOrder(migrations);
+    const parentMap = new Map(
+      ordered.map((m, index) => [m.version, effectiveParents(m, index, ordered)]),
+    );
 
-    const result: MigrationStatus[] = sortByVersion(migrations).map((m) => {
+    const result: MigrationStatus[] = ordered.map((m) => {
       const entry = appliedMap.get(m.version);
       return {
         version: m.version,
         name: m.name,
         isApplied: entry !== undefined,
         appliedAt: entry?.appliedAt,
+        parent: parentMap.get(m.version),
       };
     });
 
@@ -96,10 +103,16 @@ export class Migrator {
     return result;
   }
 
-  async migrate(migrations: Migration[]): Promise<Migration[]> {
+  async migrate(migrations: Migration[], options: MigrateOptions = {}): Promise<Migration[]> {
     const pending = await this.pending(migrations);
-    for (const migration of pending) {
-      await this.runUp(migration);
+    if (pending.length === 0) return pending;
+
+    if (options.parallel) {
+      await this.migrateInWaves(pending);
+    } else {
+      for (const migration of pending) {
+        await this.runUp(migration);
+      }
     }
     return pending;
   }
@@ -122,17 +135,56 @@ export class Migrator {
 
   async rollback(migrations: Migration[], steps = 1): Promise<Migration[]> {
     if (steps <= 0) return [];
-    const applied = await this.appliedVersions();
+    const applied = new Set(await this.appliedVersions());
     const byVersion = new Map(migrations.map((m) => [m.version, m]));
-    const targets = applied.slice(-steps).reverse();
+
+    for (const version of applied) {
+      if (!byVersion.has(version)) throw new MigrationMissingError(version);
+    }
+
+    const ordered = topologicalOrder(migrations).filter((m) => applied.has(m.version));
+    const targets = ordered.slice(-steps).reverse();
+
     const reverted: Migration[] = [];
-    for (const version of targets) {
-      const migration = byVersion.get(version);
-      if (!migration) throw new MigrationMissingError(version);
+    for (const migration of targets) {
       await this.runDown(migration);
       reverted.push(migration);
     }
     return reverted;
+  }
+
+  private async migrateInWaves(pending: Migration[]): Promise<void> {
+    const pendingVersions = new Set(pending.map((m) => m.version));
+    const pendingList = pending;
+    const parentsByVersion = new Map<string, string[]>();
+    for (let i = 0; i < pendingList.length; i++) {
+      const migration = pendingList[i];
+      const parents = effectiveParents(migration, i, pendingList).filter((p) =>
+        pendingVersions.has(p),
+      );
+      parentsByVersion.set(migration.version, parents);
+    }
+
+    const remaining = new Map(pendingList.map((m) => [m.version, m]));
+    const applied = new Set<string>();
+
+    while (remaining.size > 0) {
+      const wave: Migration[] = [];
+      for (const migration of remaining.values()) {
+        const parents = parentsByVersion.get(migration.version) ?? [];
+        if (parents.every((p) => applied.has(p))) {
+          wave.push(migration);
+        }
+      }
+      if (wave.length === 0) {
+        throw new MigrationCycleError([...remaining.keys()]);
+      }
+      await Promise.all(wave.map((migration) => this.runUp(migration)));
+      for (const migration of wave) {
+        applied.add(migration.version);
+        remaining.delete(migration.version);
+      }
+    }
   }
 
   private async runUp(migration: Migration): Promise<void> {
@@ -161,6 +213,55 @@ export class Migrator {
 
 function sortByVersion(migrations: Migration[]): Migration[] {
   return [...migrations].sort((a, b) => a.version.localeCompare(b.version));
+}
+
+function effectiveParents(migration: Migration, index: number, sorted: Migration[]): string[] {
+  if (migration.parent !== undefined) return migration.parent;
+  if (index === 0) return [];
+  return [sorted[index - 1].version];
+}
+
+function topologicalOrder(migrations: Migration[]): Migration[] {
+  const sorted = sortByVersion(migrations);
+  const known = new Set(sorted.map((m) => m.version));
+
+  const parents = new Map<string, string[]>();
+  for (let i = 0; i < sorted.length; i++) {
+    const migration = sorted[i];
+    const declared = effectiveParents(migration, i, sorted);
+    for (const parent of declared) {
+      if (!known.has(parent)) {
+        throw new MigrationParentMissingError(migration.version, parent);
+      }
+    }
+    parents.set(migration.version, declared);
+  }
+
+  const byVersion = new Map(sorted.map((m) => [m.version, m]));
+  const ordered: Migration[] = [];
+  const placed = new Set<string>();
+  const remaining = new Set(sorted.map((m) => m.version));
+
+  while (remaining.size > 0) {
+    const wave: string[] = [];
+    for (const version of sorted.map((m) => m.version)) {
+      if (!remaining.has(version)) continue;
+      const deps = parents.get(version) ?? [];
+      if (deps.every((d) => placed.has(d))) {
+        wave.push(version);
+      }
+    }
+    if (wave.length === 0) {
+      throw new MigrationCycleError([...remaining]);
+    }
+    for (const version of wave) {
+      ordered.push(byVersion.get(version)!);
+      placed.add(version);
+      remaining.delete(version);
+    }
+  }
+
+  return ordered;
 }
 
 export default Migrator;

--- a/packages/migrations/src/__tests__/Migrator.spec.ts
+++ b/packages/migrations/src/__tests__/Migrator.spec.ts
@@ -4,8 +4,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   MigrationAlreadyAppliedError,
+  MigrationCycleError,
   MigrationMissingError,
   MigrationNotAppliedError,
+  MigrationParentMissingError,
   Migrator,
 } from '..';
 import type { Migration } from '../types';
@@ -277,6 +279,88 @@ for (const backend of backends) {
         await custom.migrate([createUsersTable()]);
         expect(await connector.hasTable('my_migrations')).toBe(true);
         expect(await custom.appliedVersions()).toEqual(['20250101000000']);
+      });
+    });
+
+    describe('dependency graph', () => {
+      function makeMigration(version: string, parent?: string[]): Migration {
+        return {
+          version,
+          name: `m_${version}`,
+          parent,
+          async up(connector) {
+            await connector.createTable(`t_${version}`, (t) => {
+              t.integer('id', { primary: true });
+            });
+          },
+          async down(connector) {
+            await connector.dropTable(`t_${version}`);
+          },
+        };
+      }
+
+      it('respects explicit parents when ordering migrations', async () => {
+        const root = makeMigration('20250101000000', []);
+        const branchA = makeMigration('20250102000000', ['20250101000000']);
+        const branchB = makeMigration('20250103000000', ['20250101000000']);
+        const merge = makeMigration('20250104000000', ['20250102000000', '20250103000000']);
+
+        const applied = await migrator.migrate([merge, branchB, branchA, root]);
+        const order = applied.map((m) => m.version);
+        expect(order[0]).toBe('20250101000000');
+        expect(order[3]).toBe('20250104000000');
+        expect(order.indexOf('20250102000000')).toBeLessThan(order.indexOf('20250104000000'));
+        expect(order.indexOf('20250103000000')).toBeLessThan(order.indexOf('20250104000000'));
+      });
+
+      it('throws MigrationParentMissingError when a declared parent is absent', async () => {
+        const orphan = makeMigration('20250102000000', ['20250199000000']);
+        await expect(migrator.migrate([orphan])).rejects.toBeInstanceOf(
+          MigrationParentMissingError,
+        );
+      });
+
+      it('throws MigrationCycleError when dependencies form a cycle', async () => {
+        const a = makeMigration('20250101000000', ['20250102000000']);
+        const b = makeMigration('20250102000000', ['20250101000000']);
+        await expect(migrator.migrate([a, b])).rejects.toBeInstanceOf(MigrationCycleError);
+      });
+
+      it('applies migrations in waves when parallel is true', async () => {
+        const root = makeMigration('20250101000000', []);
+        const branchA = makeMigration('20250102000000', ['20250101000000']);
+        const branchB = makeMigration('20250103000000', ['20250101000000']);
+        const merge = makeMigration('20250104000000', ['20250102000000', '20250103000000']);
+
+        const applied = await migrator.migrate([merge, branchA, branchB, root], {
+          parallel: true,
+        });
+        expect(applied.map((m) => m.version).sort()).toEqual([
+          '20250101000000',
+          '20250102000000',
+          '20250103000000',
+          '20250104000000',
+        ]);
+        expect((await migrator.appliedVersions()).sort()).toEqual([
+          '20250101000000',
+          '20250102000000',
+          '20250103000000',
+          '20250104000000',
+        ]);
+      });
+
+      it('rolls back in reverse topological order', async () => {
+        const root = makeMigration('20250101000000', []);
+        const child = makeMigration('20250102000000', ['20250101000000']);
+        const grandchild = makeMigration('20250103000000', ['20250102000000']);
+
+        await migrator.migrate([root, child, grandchild]);
+        const reverted = await migrator.rollback([root, child, grandchild], 3);
+        expect(reverted.map((m) => m.version)).toEqual([
+          '20250103000000',
+          '20250102000000',
+          '20250101000000',
+        ]);
       });
     });
   });

--- a/packages/migrations/src/errors.ts
+++ b/packages/migrations/src/errors.ts
@@ -25,3 +25,25 @@ export class MigrationMissingError extends MigrationError {
     this.name = 'MigrationMissingError';
   }
 }
+
+export class MigrationParentMissingError extends MigrationError {
+  readonly version: string;
+  readonly parent: string;
+
+  constructor(version: string, parent: string) {
+    super(`migration ${version} declares parent ${parent} which is not in the provided list`);
+    this.name = 'MigrationParentMissingError';
+    this.version = version;
+    this.parent = parent;
+  }
+}
+
+export class MigrationCycleError extends MigrationError {
+  readonly versions: string[];
+
+  constructor(versions: string[]) {
+    super(`migration dependency cycle detected involving: ${versions.join(', ')}`);
+    this.name = 'MigrationCycleError';
+    this.versions = versions;
+  }
+}

--- a/packages/migrations/src/index.ts
+++ b/packages/migrations/src/index.ts
@@ -1,3 +1,3 @@
 export * from './Migrator';
 export * from './errors';
-export type { Migration, MigrationStatus, MigratorOptions } from './types';
+export type { MigrateOptions, Migration, MigrationStatus, MigratorOptions } from './types';

--- a/packages/migrations/src/types.ts
+++ b/packages/migrations/src/types.ts
@@ -3,6 +3,13 @@ import type { Connector } from '@next-model/core';
 export interface Migration {
   version: string;
   name?: string;
+  /**
+   * Versions that must be applied before this migration runs. When omitted,
+   * the migration falls back to the migration with the next-lower version in
+   * the provided list (the implicit "previous version" chain). An empty array
+   * means "no parents" — the migration is a root node.
+   */
+  parent?: string[];
   up(connector: Connector): Promise<void>;
   down(connector: Connector): Promise<void>;
 }
@@ -12,6 +19,16 @@ export interface MigrationStatus {
   name?: string;
   isApplied: boolean;
   appliedAt?: string;
+  parent?: string[];
+}
+
+export interface MigrateOptions {
+  /**
+   * Run migrations within each dependency wave concurrently using
+   * `Promise.all`. Requires the connector to support concurrent transactions
+   * safely; when in doubt leave this `false` (the default).
+   */
+  parallel?: boolean;
 }
 
 export interface MigratorOptions {


### PR DESCRIPTION
## Summary

Stacked on #74 (PR 32). Extends `@next-model/migrations` with optional explicit migration dependencies and wave-based parallel application.

- **`Migration.parent?: string[]`** lets a migration declare the prior versions it depends on. Omitted falls back to the implicit *previous version* chain; `[]` marks a root node.
- **Topological ordering** everywhere: `migrate`, `rollback`, `pending`, and `status` all walk migrations in dependency order (rollback reversed). Cycles raise `MigrationCycleError`; unknown parents raise `MigrationParentMissingError`.
- **`migrate(migrations, { parallel: true })`** applies each dependency wave via `Promise.all`, so migrations that share no ancestor run side-by-side. Sequential mode stays the default.

This re-adds the parallel-apply feature from the reference `node-postgres-migrator` packages that were removed in PR 32, now as a first-class option on the generic `Migrator`.

## Test plan

- [x] `pnpm --filter @next-model/migrations test` — 52 tests pass (covers explicit parents, wave-based parallel apply, cycle detection, missing-parent error, reverse-topological rollback)
- [x] `pnpm -r test` — 5422 tests pass across workspace
- [x] `pnpm -r exec tsc --noEmit` — clean
- [x] `pnpm exec biome check .` — clean