### PR TITLE
PR 36: Run knex-connector tests against Postgres + MySQL in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,50 @@ jobs:
       - run: pnpm -r build
       - run: pnpm typecheck
       - run: pnpm test
+
+  test-knex-real-db:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        client: [pg, mysql2]
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: mysql
+          MYSQL_DATABASE: test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost -pmysql"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @next-model/core --filter @next-model/knex-connector -r build
+      - name: Test knex-connector against ${{ matrix.client }}
+        env:
+          KNEX_TEST_CLIENT: ${{ matrix.client }}
+          DATABASE_URL: ${{ matrix.client == 'pg' && 'postgres://postgres:postgres@127.0.0.1:5432/postgres' || 'mysql://root:mysql@127.0.0.1:3306/test' }}
+        run: pnpm --filter @next-model/knex-connector test

--- a/packages/knex-connector/HISTORY.md
+++ b/packages/knex-connector/HISTORY.md
@@ -7,6 +7,7 @@ Rewritten to match the current `@next-model/core` connector interface.
 ### Test matrix
 
 - The connector spec is now driver-agnostic and runs against sqlite3 (default), Postgres 17, and MySQL 8. CI spins up real Postgres + MySQL service containers and runs the same suite under `KNEX_TEST_CLIENT=pg` / `KNEX_TEST_CLIENT=mysql2`. Local runs default to sqlite3 in-memory.
+- Fixed `batchInsert` on MySQL: the driver only returns the first inserted id for a bulk `INSERT`, so the connector now expands `[firstId]` to `[firstId, firstId+1, …]` (safe under InnoDB's contiguous lock mode for a single statement) and re-fetches all rows. Previously only the first row of a multi-row batchInsert was returned.
 
 ### Filter operators
 - Added `$like`, `$async`, and `$raw` on top of existing boolean/set/range/comparison operators.

--- a/packages/knex-connector/HISTORY.md
+++ b/packages/knex-connector/HISTORY.md
@@ -4,6 +4,10 @@
 
 Rewritten to match the current `@next-model/core` connector interface.
 
+### Test matrix
+
+- The connector spec is now driver-agnostic and runs against sqlite3 (default), Postgres 17, and MySQL 8. CI spins up real Postgres + MySQL service containers and runs the same suite under `KNEX_TEST_CLIENT=pg` / `KNEX_TEST_CLIENT=mysql2`. Local runs default to sqlite3 in-memory.
+
 ### Filter operators
 - Added `$like`, `$async`, and `$raw` on top of existing boolean/set/range/comparison operators.
 - Consolidated `$gt`/`$gte`/`$lt`/`$lte` under a single `compareFilter` helper.

--- a/packages/knex-connector/package.json
+++ b/packages/knex-connector/package.json
@@ -41,6 +41,8 @@
     "@next-model/core": "workspace:*",
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^4.1.5",
+    "mysql2": "^3.11.5",
+    "pg": "^8.13.1",
     "sqlite3": "^6.0.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"

--- a/packages/knex-connector/src/KnexConnector.ts
+++ b/packages/knex-connector/src/KnexConnector.ts
@@ -305,7 +305,12 @@ export class KnexConnector implements Connector {
     if (typeof idsOrRows[0] === 'object') {
       return idsOrRows as Dict<any>[];
     }
-    const ids = idsOrRows as number[];
+    const returnedIds = idsOrRows as number[];
+    const isMysql = clientName === 'mysql' || clientName === 'mysql2';
+    const ids =
+      isMysql && returnedIds.length === 1 && items.length > 1
+        ? items.map((_, i) => returnedIds[0] + i)
+        : returnedIds;
     const rows = (await this.table(tableName).whereIn(primaryKey, ids).select('*')) as Dict<any>[];
     const rowDict: Dict<Dict<any>> = {};
     for (const row of rows) {

--- a/packages/knex-connector/src/__tests__/KnexConnector.spec.ts
+++ b/packages/knex-connector/src/__tests__/KnexConnector.spec.ts
@@ -1,14 +1,38 @@
 import { FilterError, Model } from '@next-model/core';
-import type Knex from 'knex';
+import type { Knex } from 'knex';
 import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { KnexConnector } from '../index.js';
 
-const connector = new KnexConnector({
-  client: 'sqlite3',
-  connection: { filename: ':memory:' },
-  useNullAsDefault: true,
-});
+const TEST_CLIENT = process.env.KNEX_TEST_CLIENT ?? 'sqlite3';
+
+function buildConnector(): KnexConnector {
+  switch (TEST_CLIENT) {
+    case 'sqlite3':
+      return new KnexConnector({
+        client: 'sqlite3',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true,
+      });
+    case 'pg':
+      return new KnexConnector({
+        client: 'pg',
+        connection:
+          process.env.DATABASE_URL ?? 'postgres://postgres:postgres@127.0.0.1:5432/postgres',
+        pool: { min: 1, max: 1 },
+      });
+    case 'mysql2':
+      return new KnexConnector({
+        client: 'mysql2',
+        connection: process.env.DATABASE_URL ?? 'mysql://root:mysql@127.0.0.1:3306/test',
+        pool: { min: 1, max: 1 },
+      });
+    default:
+      throw new Error(`Unknown KNEX_TEST_CLIENT: ${TEST_CLIENT}`);
+  }
+}
+
+const connector = buildConnector();
 
 const tableName = 'users';
 
@@ -45,6 +69,10 @@ async function seed(): Promise<void> {
 }
 
 const ids = (rows: { id: number }[]) => rows.map((r) => r.id);
+const sortedIds = (rows: { id: number }[]) =>
+  ids(rows)
+    .slice()
+    .sort((a, b) => a - b);
 
 afterEach(dropTable);
 afterAll(() => connector.knex.destroy());
@@ -55,25 +83,30 @@ describe('KnexConnector', () => {
 
     it('returns all rows for an empty filter', async () => {
       const rows = await connector.query({ tableName });
-      expect(ids(rows as any)).toEqual([alice.id, bob.id, carol.id]);
+      expect(sortedIds(rows as any)).toEqual([alice.id, bob.id, carol.id]);
     });
 
     it('filters by property equality', async () => {
       const rows = await connector.query({ tableName, filter: { age: 21 } });
-      expect(ids(rows as any)).toEqual([bob.id, carol.id]);
+      expect(sortedIds(rows as any)).toEqual([bob.id, carol.id]);
     });
 
     it('respects limit and skip', async () => {
-      const rows = await connector.query({ tableName, limit: 1, skip: 1 });
+      const rows = await connector.query({
+        tableName,
+        order: [{ key: 'id' }],
+        limit: 1,
+        skip: 1,
+      });
       expect(ids(rows as any)).toEqual([bob.id]);
     });
 
-    it('orders rows', async () => {
+    it('orders rows ascending by a numeric column', async () => {
       const rows = await connector.query({
         tableName,
-        order: [{ key: 'name' }],
+        order: [{ key: 'age' }, { key: 'id' }],
       });
-      expect((rows as any[]).map((r) => r.name)).toEqual([null, 'alice', 'bar']);
+      expect(ids(rows as any)).toEqual([alice.id, bob.id, carol.id]);
     });
 
     describe('filter operators', () => {
@@ -90,7 +123,7 @@ describe('KnexConnector', () => {
           tableName,
           filter: { $or: [{ id: alice.id }, { id: carol.id }] },
         });
-        expect(ids(rows as any)).toEqual([alice.id, carol.id]);
+        expect(sortedIds(rows as any)).toEqual([alice.id, carol.id]);
       });
 
       it('$not', async () => {
@@ -98,7 +131,7 @@ describe('KnexConnector', () => {
           tableName,
           filter: { $not: { id: bob.id } },
         });
-        expect(ids(rows as any)).toEqual([alice.id, carol.id]);
+        expect(sortedIds(rows as any)).toEqual([alice.id, carol.id]);
       });
 
       it('$in', async () => {
@@ -106,7 +139,7 @@ describe('KnexConnector', () => {
           tableName,
           filter: { $in: { id: [alice.id, carol.id] } },
         });
-        expect(ids(rows as any)).toEqual([alice.id, carol.id]);
+        expect(sortedIds(rows as any)).toEqual([alice.id, carol.id]);
       });
 
       it('$notIn', async () => {
@@ -114,17 +147,17 @@ describe('KnexConnector', () => {
           tableName,
           filter: { $notIn: { id: [alice.id] } },
         });
-        expect(ids(rows as any)).toEqual([bob.id, carol.id]);
+        expect(sortedIds(rows as any)).toEqual([bob.id, carol.id]);
       });
 
       it('$null', async () => {
         const rows = await connector.query({ tableName, filter: { $null: 'name' } });
-        expect(ids(rows as any)).toEqual([bob.id]);
+        expect(sortedIds(rows as any)).toEqual([bob.id]);
       });
 
       it('$notNull', async () => {
         const rows = await connector.query({ tableName, filter: { $notNull: 'name' } });
-        expect(ids(rows as any)).toEqual([alice.id, carol.id]);
+        expect(sortedIds(rows as any)).toEqual([alice.id, carol.id]);
       });
 
       it('$between', async () => {
@@ -132,7 +165,7 @@ describe('KnexConnector', () => {
           tableName,
           filter: { $between: { age: { from: 20, to: 30 } } },
         });
-        expect(ids(rows as any)).toEqual([bob.id, carol.id]);
+        expect(sortedIds(rows as any)).toEqual([bob.id, carol.id]);
       });
 
       it('$notBetween', async () => {
@@ -140,21 +173,21 @@ describe('KnexConnector', () => {
           tableName,
           filter: { $notBetween: { age: { from: 20, to: 30 } } },
         });
-        expect(ids(rows as any)).toEqual([alice.id]);
+        expect(sortedIds(rows as any)).toEqual([alice.id]);
       });
 
       it('$gt / $gte / $lt / $lte', async () => {
         expect(
-          ids((await connector.query({ tableName, filter: { $gt: { age: 20 } } })) as any),
+          sortedIds((await connector.query({ tableName, filter: { $gt: { age: 20 } } })) as any),
         ).toEqual([bob.id, carol.id]);
         expect(
-          ids((await connector.query({ tableName, filter: { $gte: { age: 21 } } })) as any),
+          sortedIds((await connector.query({ tableName, filter: { $gte: { age: 21 } } })) as any),
         ).toEqual([bob.id, carol.id]);
         expect(
-          ids((await connector.query({ tableName, filter: { $lt: { age: 21 } } })) as any),
+          sortedIds((await connector.query({ tableName, filter: { $lt: { age: 21 } } })) as any),
         ).toEqual([alice.id]);
         expect(
-          ids((await connector.query({ tableName, filter: { $lte: { age: 18 } } })) as any),
+          sortedIds((await connector.query({ tableName, filter: { $lte: { age: 18 } } })) as any),
         ).toEqual([alice.id]);
       });
 
@@ -163,7 +196,7 @@ describe('KnexConnector', () => {
           tableName,
           filter: { $like: { name: 'ali%' } },
         });
-        expect(ids(rows as any)).toEqual([alice.id]);
+        expect(sortedIds(rows as any)).toEqual([alice.id]);
       });
 
       it('$raw', async () => {
@@ -171,7 +204,7 @@ describe('KnexConnector', () => {
           tableName,
           filter: { $raw: { $query: 'age = ?', $bindings: [18] } },
         });
-        expect(ids(rows as any)).toEqual([alice.id]);
+        expect(sortedIds(rows as any)).toEqual([alice.id]);
       });
 
       it('$async resolves lazy filters', async () => {
@@ -179,7 +212,7 @@ describe('KnexConnector', () => {
           tableName,
           filter: { $async: Promise.resolve({ age: 18 }) },
         });
-        expect(ids(rows as any)).toEqual([alice.id]);
+        expect(sortedIds(rows as any)).toEqual([alice.id]);
       });
 
       it('rejects filter with multiple keys in $gt with FilterError', async () => {
@@ -220,13 +253,13 @@ describe('KnexConnector', () => {
     beforeEach(seed);
 
     it('returns only the requested columns', async () => {
-      const rows = await connector.select({ tableName }, 'name');
+      const rows = await connector.select({ tableName, order: [{ key: 'id' }] }, 'name');
       expect(rows).toEqual([{ name: 'alice' }, { name: null }, { name: 'bar' }]);
     });
 
     it('respects filter and order', async () => {
       const rows = await connector.select(
-        { tableName, filter: { age: 21 }, order: [{ key: 'name' }] },
+        { tableName, filter: { age: 21 }, order: [{ key: 'id' }] },
         'name',
         'age',
       );
@@ -271,9 +304,9 @@ describe('KnexConnector', () => {
 
     it('deletes matching rows and returns what was deleted', async () => {
       const deleted = await connector.deleteAll({ tableName, filter: { age: 21 } });
-      expect(ids(deleted as any).sort()).toEqual([bob.id, carol.id].sort());
+      expect(sortedIds(deleted as any)).toEqual([bob.id, carol.id]);
       const remaining = await connector.query({ tableName });
-      expect(ids(remaining as any)).toEqual([alice.id]);
+      expect(sortedIds(remaining as any)).toEqual([alice.id]);
     });
 
     it('returns an empty array when no rows match', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 2.1.4
       knex:
         specifier: ^3.2.9
-        version: 3.2.9(sqlite3@6.0.1)
+        version: 3.2.9(mysql2@3.22.2(@types/node@25.6.0))(pg@8.20.0)(sqlite3@6.0.1)
     devDependencies:
       '@next-model/core':
         specifier: workspace:*
@@ -62,7 +62,7 @@ importers:
     dependencies:
       knex:
         specifier: ^3.2.9
-        version: 3.2.9(sqlite3@6.0.1)
+        version: 3.2.9(mysql2@3.22.2(@types/node@25.6.0))(pg@8.20.0)(sqlite3@6.0.1)
     devDependencies:
       '@next-model/core':
         specifier: workspace:*
@@ -73,6 +73,12 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
+      mysql2:
+        specifier: ^3.11.5
+        version: 3.22.2(@types/node@25.6.0)
+      pg:
+        specifier: ^8.13.1
+        version: 8.20.0
       sqlite3:
         specifier: ^6.0.1
         version: 6.0.1
@@ -119,7 +125,7 @@ importers:
         version: 4.1.5(vitest@4.1.5)
       knex:
         specifier: ^3.2.9
-        version: 3.2.9(sqlite3@6.0.1)
+        version: 3.2.9(mysql2@3.22.2(@types/node@25.6.0))(pg@8.20.0)(sqlite3@6.0.1)
       sqlite3:
         specifier: ^6.0.1
         version: 6.0.1
@@ -397,6 +403,10 @@ packages:
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
+  aws-ssl-profiles@1.1.2:
+    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
+    engines: {node: '>= 6.0.0'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -454,6 +464,10 @@ packages:
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -518,6 +532,9 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
@@ -542,6 +559,10 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -558,6 +579,9 @@ packages:
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
+
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
   isexe@4.0.0:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
@@ -682,6 +706,13 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru.min@1.1.4:
+    resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
+    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -712,6 +743,16 @@ packages:
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
+  mysql2@3.22.2:
+    resolution: {integrity: sha512-snC/L6YoCJPFpozZo3p3hiOlt9ItQ7sCnLSziFLlIttEzsPhrdcPT8g21BiQ7Oqif25W4Xq1IFuBzBvoFYDf0Q==}
+    engines: {node: '>= 8.0'}
+    peerDependencies:
+      '@types/node': '>= 8'
+
+  named-placeholders@1.1.6:
+    resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
+    engines: {node: '>=8.0.0'}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -751,8 +792,42 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
   pg-connection-string@2.6.2:
     resolution: {integrity: sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -764,6 +839,22 @@ packages:
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -807,6 +898,9 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -824,6 +918,14 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  sql-escaper@1.3.3:
+    resolution: {integrity: sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==}
+    engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
 
   sqlite3@6.0.1:
     resolution: {integrity: sha512-X0czUUMG2tmSqJpEQa3tCuZSHKIx8PwM53vLZzKp/o6Rpy25fiVfjdbnZ988M8+O3ZWR1ih0K255VumCb3MAnQ==}
@@ -1005,6 +1107,10 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
@@ -1237,6 +1343,8 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  aws-ssl-profiles@1.1.2: {}
+
   base64-js@1.5.1: {}
 
   bindings@1.5.0:
@@ -1280,6 +1388,8 @@ snapshots:
 
   deep-extend@0.6.0: {}
 
+  denque@2.1.0: {}
+
   detect-libc@2.1.2: {}
 
   end-of-stream@1.4.5:
@@ -1321,6 +1431,10 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+
   get-package-type@0.1.0: {}
 
   getopts@2.3.0: {}
@@ -1338,6 +1452,10 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   inherits@2.0.4: {}
@@ -1349,6 +1467,8 @@ snapshots:
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.3
+
+  is-property@1.0.2: {}
 
   isexe@4.0.0:
     optional: true
@@ -1368,7 +1488,7 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  knex@3.2.9(sqlite3@6.0.1):
+  knex@3.2.9(mysql2@3.22.2(@types/node@25.6.0))(pg@8.20.0)(sqlite3@6.0.1):
     dependencies:
       colorette: 2.0.19
       commander: 10.0.1
@@ -1385,6 +1505,8 @@ snapshots:
       tarn: 3.0.2
       tildify: 2.0.0
     optionalDependencies:
+      mysql2: 3.22.2(@types/node@25.6.0)
+      pg: 8.20.0
       sqlite3: 6.0.1
     transitivePeerDependencies:
       - supports-color
@@ -1440,6 +1562,10 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  long@5.3.2: {}
+
+  lru.min@1.1.4: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1467,6 +1593,22 @@ snapshots:
   mkdirp-classic@0.5.3: {}
 
   ms@2.1.2: {}
+
+  mysql2@3.22.2(@types/node@25.6.0):
+    dependencies:
+      '@types/node': 25.6.0
+      aws-ssl-profiles: 1.1.2
+      denque: 2.1.0
+      generate-function: 2.3.1
+      iconv-lite: 0.7.2
+      long: 5.3.2
+      lru.min: 1.1.4
+      named-placeholders: 1.1.6
+      sql-escaper: 1.3.3
+
+  named-placeholders@1.1.6:
+    dependencies:
+      lru.min: 1.1.4
 
   nanoid@3.3.11: {}
 
@@ -1507,7 +1649,42 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
   pg-connection-string@2.6.2: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   picocolors@1.1.1: {}
 
@@ -1518,6 +1695,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prebuild-install@7.1.3:
     dependencies:
@@ -1591,6 +1778,8 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safer-buffer@2.1.2: {}
+
   semver@7.7.4: {}
 
   siginfo@2.0.0: {}
@@ -1604,6 +1793,10 @@ snapshots:
       simple-concat: 1.0.1
 
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
+
+  sql-escaper@1.3.3: {}
 
   sqlite3@6.0.1:
     dependencies:
@@ -1736,5 +1929,7 @@ snapshots:
       stackback: 0.0.2
 
   wrappy@1.0.2: {}
+
+  xtend@4.0.2: {}
 
   yallist@5.0.0: {}


### PR DESCRIPTION
## Summary

Spins up real Postgres 17 and MySQL 8 service containers in CI and runs the full `KnexConnector` spec against each driver, in addition to the existing sqlite3 in-memory run.

- `KnexConnector.spec.ts` is now driver-agnostic: a `buildConnector()` switch reads `KNEX_TEST_CLIENT` (default `sqlite3`) and constructs the connector with a connection string from `DATABASE_URL`.
- Order-sensitive assertions made deterministic across drivers:
  - `sortedIds()` helper for set-comparisons (no implicit reliance on insert-order).
  - Explicit `order: [{ key: 'id' }]` on `limit`/`skip` and `select` tests where row order is asserted.
  - The original "orders rows" test (which expected sqlite NULL-first ordering) now uses `age` to dodge the sqlite/mysql/pg NULL-position divergence.
- Added `pg` and `mysql2` as devDependencies of `@next-model/knex-connector`.
- New `test-knex-real-db` job in `.github/workflows/ci.yml`, matrixed by `client: [pg, mysql2]`, with health-checked service containers.

Stacked on #79.

## Test plan

- [x] Local `pnpm --filter @next-model/knex-connector test` — sqlite3 path still passes (43 tests)
- [x] CI `test (22.x)` and `test (24.x)` jobs stay green (sqlite3)
- [x] CI `test-knex-real-db (pg)` job passes
- [x] CI `test-knex-real-db (mysql2)` job passes