### PR TITLE
PR 37: Shared connector conformance suite + coverage gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - run: pnpm lint
       - run: pnpm -r build
       - run: pnpm typecheck
-      - run: pnpm test
+      - run: pnpm -r coverage
 
   test-knex-real-db:
     runs-on: ubuntu-latest

--- a/packages/core/HISTORY.md
+++ b/packages/core/HISTORY.md
@@ -12,6 +12,9 @@ Rolling changelog for the next major release. Items below are appended in the or
 - Replaced Travis CI with GitHub Actions (typecheck + lint + tests on every branch/PR).
 - Bumped toolchain to TypeScript 6, `@types/node` 25, and `@vitest/coverage-v8` 4 across every package. Knex connectors moved to knex 3 (from 0.19); the `data-api-client` dependency jumped to 2.x. `lib`/`target` raised to `ES2023` and `structuredClone` is now sourced via `@types/node` globals. Removed the dead `faker` / `@types/faker` / `@types/knex` dev deps (faker was never used; knex bundles its own types since 0.95). `pnpm audit` reports zero vulnerabilities.
 - Build modernization: every package is now pure ESM (`"type": "module"`, `exports` field, `.js` extensions on relative imports) built with `module: NodeNext`. Dropped the `tsc-mjs` dual-build. `dist/` is no longer tracked in git and is rebuilt via `pnpm build` / `prepublishOnly`.
+- Shared `runModelConformance` test helper (`@next-model/conformance`) gives every connector the same Model-level CRUD/Query/Transactions/Schema-DSL coverage. Wired into MemoryConnector, KnexConnector (sqlite/pg/mysql) and LocalStorageConnector specs. CI now runs `pnpm -r coverage` and each package's vitest config enforces coverage thresholds.
+- Schema DSL: `ColumnOptions.autoIncrement` now generates `t.increments(...)` on KnexConnector, so a table created via the DSL works with `KeyType.number` Models out of the box.
+- KnexConnector: `deleteAll`/`updateAll` no longer apply `limit`/`skip` to the underlying knex builder, fixing a sqlite "limit has no effect on a delete" error when the Model layer sets `limit: 1` on its single-row scope.
 
 ### Factory & configuration
 

--- a/packages/core/src/__tests__/MemoryConnector.spec.ts
+++ b/packages/core/src/__tests__/MemoryConnector.spec.ts
@@ -1186,3 +1186,10 @@ describe('Connector', () => {
     });
   });
 });
+
+import { runModelConformance } from './conformance.js';
+
+runModelConformance({
+  name: 'MemoryConnector',
+  makeConnector: () => new MemoryConnector({ storage: {} }),
+});

--- a/packages/core/src/__tests__/conformance.ts
+++ b/packages/core/src/__tests__/conformance.ts
@@ -1,0 +1,148 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { Model } from '../Model.js';
+import type { Connector } from '../types.js';
+
+export interface ConformanceOptions {
+  name: string;
+  makeConnector: () => Connector | Promise<Connector>;
+  /** Optional teardown after the whole suite (e.g. `connector.knex.destroy()`). */
+  teardown?: (connector: Connector) => Promise<void>;
+  /** Skip transaction tests when the connector doesn't support real transactions. */
+  skipTransactions?: boolean;
+}
+
+interface CatProps {
+  name: string;
+  age: number;
+}
+
+export function runModelConformance(opts: ConformanceOptions): void {
+  describe(`Model conformance — ${opts.name}`, () => {
+    let connector: Connector;
+    let Cat: ReturnType<typeof makeCat>;
+    const tableName = 'conformance_cats';
+
+    function makeCat(c: Connector) {
+      return class extends Model({
+        tableName,
+        connector: c,
+        timestamps: false,
+        init: (props: CatProps) => props,
+      }) {};
+    }
+
+    beforeEach(async () => {
+      connector = await opts.makeConnector();
+      Cat = makeCat(connector);
+      if (await connector.hasTable(tableName)) {
+        await connector.dropTable(tableName);
+      }
+      await connector.createTable(tableName, (t) => {
+        t.integer('id', { primary: true, autoIncrement: true, null: false });
+        t.string('name');
+        t.integer('age');
+      });
+    });
+
+    afterAll(async () => {
+      if (opts.teardown) await opts.teardown(connector);
+    });
+
+    describe('CRUD', () => {
+      it('creates a row and assigns an id', async () => {
+        const cat = await Cat.create({ name: 'Whiskers', age: 5 });
+        expect(cat.id).toBeDefined();
+        expect(cat.name).toBe('Whiskers');
+        expect(cat.age).toBe(5);
+      });
+
+      it('finds an existing row by id', async () => {
+        const created = await Cat.create({ name: 'Mittens', age: 3 });
+        const found = await Cat.find(created.id);
+        expect(found?.name).toBe('Mittens');
+      });
+
+      it('returns undefined via findBy for a missing id', async () => {
+        expect(await Cat.findBy({ id: 99999 })).toBeUndefined();
+      });
+
+      it('updates an instance', async () => {
+        const cat = await Cat.create({ name: 'Tom', age: 4 });
+        await cat.update({ age: 5 });
+        const reloaded = await Cat.find(cat.id);
+        expect(reloaded?.age).toBe(5);
+      });
+
+      it('deletes an instance', async () => {
+        const cat = await Cat.create({ name: 'Goner', age: 9 });
+        const id = cat.id;
+        await cat.delete();
+        expect(await Cat.findBy({ id })).toBeUndefined();
+      });
+    });
+
+    describe('Query', () => {
+      beforeEach(async () => {
+        await Cat.create({ name: 'a', age: 1 });
+        await Cat.create({ name: 'b', age: 2 });
+        await Cat.create({ name: 'c', age: 3 });
+      });
+
+      it('counts rows', async () => {
+        expect(await Cat.count()).toBe(3);
+      });
+
+      it('filters by equality', async () => {
+        const cats = await Cat.filterBy({ age: 2 }).all();
+        expect(cats.map((c) => c.name)).toEqual(['b']);
+      });
+
+      it('orders rows by a column', async () => {
+        const cats = await Cat.orderBy({ key: 'age' }).all();
+        expect(cats.map((c) => c.age)).toEqual([1, 2, 3]);
+      });
+
+      it('limits and skips', async () => {
+        const cats = await Cat.orderBy({ key: 'age' }).limitBy(1).skipBy(1).all();
+        expect(cats.map((c) => c.age)).toEqual([2]);
+      });
+
+      it('aggregates sum/min/max/avg', async () => {
+        expect(await Cat.sum('age')).toBe(6);
+        expect(await Cat.min('age')).toBe(1);
+        expect(await Cat.max('age')).toBe(3);
+        expect(await Cat.avg('age')).toBe(2);
+      });
+    });
+
+    if (!opts.skipTransactions) {
+      describe('Transactions', () => {
+        it('commits on success', async () => {
+          await connector.transaction(async () => {
+            await Cat.create({ name: 'tx-a', age: 10 });
+            await Cat.create({ name: 'tx-b', age: 11 });
+          });
+          expect(await Cat.count()).toBe(2);
+        });
+
+        it('rolls back on throw', async () => {
+          await expect(
+            connector.transaction(async () => {
+              await Cat.create({ name: 'doomed', age: 99 });
+              throw new Error('boom');
+            }),
+          ).rejects.toThrow('boom');
+          expect(await Cat.count()).toBe(0);
+        });
+      });
+    }
+
+    describe('Schema DSL', () => {
+      it('reports hasTable for existing table and false after drop', async () => {
+        expect(await connector.hasTable(tableName)).toBe(true);
+        await connector.dropTable(tableName);
+        expect(await connector.hasTable(tableName)).toBe(false);
+      });
+    });
+  });
+}

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -21,6 +21,7 @@ export interface ColumnOptions {
   unique?: boolean;
   precision?: number;
   scale?: number;
+  autoIncrement?: boolean;
 }
 
 export interface IndexOptions {
@@ -38,6 +39,7 @@ export interface ColumnDefinition {
   unique: boolean;
   precision?: number;
   scale?: number;
+  autoIncrement: boolean;
 }
 
 export interface IndexDefinition {
@@ -85,6 +87,7 @@ class TableBuilderImpl implements TableBuilder {
       unique: options.unique ?? false,
       precision: options.precision,
       scale: options.scale,
+      autoIncrement: options.autoIncrement ?? false,
     });
     return this;
   }

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -7,6 +7,12 @@ export default defineConfig({
     coverage: {
       include: ['src/**/*.ts'],
       exclude: ['src/__benchmark__/**', 'src/__tests__/**', 'src/__mocks__/**'],
+      thresholds: {
+        lines: 85,
+        statements: 85,
+        functions: 80,
+        branches: 75,
+      },
     },
   },
 });

--- a/packages/data-api-connector/vitest.config.ts
+++ b/packages/data-api-connector/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@next-model/core': path.resolve(__dirname, '../core/src/index.ts'),
+      '@next-model/conformance': path.resolve(__dirname, '../core/src/__tests__/conformance.ts'),
     },
   },
   test: {
@@ -13,6 +14,12 @@ export default defineConfig({
     coverage: {
       include: ['src/**/*.ts'],
       exclude: ['src/__benchmark__/**', 'src/__tests__/**', 'src/__mocks__/**'],
+      thresholds: {
+        lines: 70,
+        statements: 70,
+        functions: 80,
+        branches: 50,
+      },
     },
   },
 });

--- a/packages/knex-connector/src/KnexConnector.ts
+++ b/packages/knex-connector/src/KnexConnector.ts
@@ -231,7 +231,8 @@ export class KnexConnector implements Connector {
     const clientName = this.knex.client.config.client;
     const supportsReturning =
       clientName !== 'sqlite3' && clientName !== 'mysql' && clientName !== 'mysql2';
-    const { query } = await this.collection(scope);
+    const table = this.table(scope.tableName);
+    const { query } = await this.filter(table, scope.filter);
     let rows: any;
     if (supportsReturning) {
       try {
@@ -254,7 +255,8 @@ export class KnexConnector implements Connector {
 
   async deleteAll(scope: Scope): Promise<Dict<any>[]> {
     const matching = await this.query(scope);
-    const { query } = await this.collection(scope);
+    const table = this.table(scope.tableName);
+    const { query } = await this.filter(table, scope.filter);
     await query.del();
     return matching;
   }
@@ -364,6 +366,11 @@ export class KnexConnector implements Connector {
     if (await this.hasTable(tableName)) return;
     await this.schemaBuilder().createTable(tableName, (table) => {
       for (const col of def.columns) {
+        if (col.autoIncrement) {
+          const auto = table.increments(col.name);
+          if (col.unique) auto.unique();
+          continue;
+        }
         const columnBuilder = buildKnexColumn(table, col);
         if (col.primary) columnBuilder.primary();
         if (col.unique) columnBuilder.unique();

--- a/packages/knex-connector/src/__tests__/KnexConnector.spec.ts
+++ b/packages/knex-connector/src/__tests__/KnexConnector.spec.ts
@@ -1,3 +1,4 @@
+import { runModelConformance } from '@next-model/conformance';
 import { FilterError, Model } from '@next-model/core';
 import type { Knex } from 'knex';
 import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -431,4 +432,9 @@ describe('KnexConnector', () => {
       expect(names).not.toContain('inner');
     });
   });
+});
+
+runModelConformance({
+  name: `KnexConnector (${TEST_CLIENT})`,
+  makeConnector: () => connector,
 });

--- a/packages/knex-connector/vitest.config.ts
+++ b/packages/knex-connector/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@next-model/core': path.resolve(__dirname, '../core/src/index.ts'),
+      '@next-model/conformance': path.resolve(__dirname, '../core/src/__tests__/conformance.ts'),
     },
   },
   test: {
@@ -13,6 +14,12 @@ export default defineConfig({
     coverage: {
       include: ['src/**/*.ts'],
       exclude: ['src/__benchmark__/**', 'src/__tests__/**', 'src/__mocks__/**'],
+      thresholds: {
+        lines: 75,
+        statements: 75,
+        functions: 85,
+        branches: 55,
+      },
     },
   },
 });

--- a/packages/local-storage-connector/src/__tests__/LocalStorageConnector.spec.ts
+++ b/packages/local-storage-connector/src/__tests__/LocalStorageConnector.spec.ts
@@ -1,3 +1,4 @@
+import { runModelConformance } from '@next-model/conformance';
 import { FilterError, Model } from '@next-model/core';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { MemoryLocalStorage } from '../__mocks__/MemoryLocalStorage.js';
@@ -418,4 +419,9 @@ describe('LocalStorageConnector', () => {
       }
     });
   });
+});
+
+runModelConformance({
+  name: 'LocalStorageConnector',
+  makeConnector: () => new LocalStorageConnector({ localStorage: new MemoryLocalStorage() }),
 });

--- a/packages/local-storage-connector/vitest.config.ts
+++ b/packages/local-storage-connector/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@next-model/core': path.resolve(__dirname, '../core/src/index.ts'),
+      '@next-model/conformance': path.resolve(__dirname, '../core/src/__tests__/conformance.ts'),
     },
   },
   test: {
@@ -13,6 +14,12 @@ export default defineConfig({
     coverage: {
       include: ['src/**/*.ts'],
       exclude: ['src/__tests__/**', 'src/__mocks__/**'],
+      thresholds: {
+        lines: 85,
+        statements: 85,
+        functions: 75,
+        branches: 85,
+      },
     },
   },
 });

--- a/packages/migrations/vitest.config.ts
+++ b/packages/migrations/vitest.config.ts
@@ -14,6 +14,12 @@ export default defineConfig({
     coverage: {
       include: ['src/**/*.ts'],
       exclude: ['src/__tests__/**'],
+      thresholds: {
+        lines: 95,
+        statements: 95,
+        functions: 95,
+        branches: 80,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

Stops every connector from re-inventing its own Model-level integration tests and starts enforcing coverage in CI.

- **`runModelConformance(opts)`** — new shared helper at `packages/core/src/__tests__/conformance.ts`, exposed to every connector test as the `@next-model/conformance` vitest alias. Exercises CRUD, query chainables, aggregates, transactions and the schema DSL through Model + Connector for any backend.
- Wired into MemoryConnector, KnexConnector (sqlite/pg/mysql) and LocalStorageConnector specs. Lifts `schema.ts` coverage in core from 0 → ~100 % and is the first thing to exercise `KnexConnector.createTable` end-to-end.
- Per-package vitest configs gain coverage thresholds at observed baselines (with small headroom). CI now runs `pnpm -r coverage` instead of `pnpm test`, so any drop fails the build.

Real bugs flushed out by the new shared suite:

- Schema DSL had no auto-increment support — added `ColumnOptions.autoIncrement` and have KnexConnector route it to `t.increments(...)`. A DSL-created table now works unchanged with `KeyType.number` Models.
- `KnexConnector.deleteAll` / `updateAll` were applying `limit`/`skip` to the underlying knex builder, which sqlite rejects (`limit has no effect on a delete`). Both now build their own scoped query without limit/offset.

Stacked on #80.

## Test plan

- [x] `pnpm -r coverage` (sqlite path) — all five packages clear their thresholds locally.
- [x] CI `test (22.x)` / `test (24.x)` jobs stay green.
- [x] CI `test-knex-real-db (pg)` and `test-knex-real-db (mysql2)` jobs stay green (now also run conformance against real Postgres/MySQL).