### PR TITLE
PR 38: README overhaul — root + connector READMEs aligned with current API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# NextModel
+
+A typed, promise-based ORM for TypeScript. Define models with a factory, chain immutable scopes, plug in any storage via the `Connector` interface, and run schema migrations against the same connector.
+
+This repository is a pnpm workspace; each published package lives under `packages/`.
+
+| Package | Purpose |
+|---------|---------|
+| [`@next-model/core`](./packages/core) | Model factory, chainable query DSL, validators, callbacks, soft deletes, associations, in-memory connector. |
+| [`@next-model/knex-connector`](./packages/knex-connector) | SQL connector backed by Knex 3 (sqlite3 / Postgres / MySQL / MariaDB / Oracle / MSSQL). |
+| [`@next-model/data-api-connector`](./packages/data-api-connector) | Connector for AWS Aurora Serverless v1 (RDS Data API). |
+| [`@next-model/local-storage-connector`](./packages/local-storage-connector) | Browser `localStorage` connector. Inherits from `MemoryConnector`. |
+| [`@next-model/migrations`](./packages/migrations) | Connector-agnostic schema migration runner with optional dependency graph. |
+
+## Quick start
+
+```ts
+import { Model, MemoryConnector } from '@next-model/core';
+
+const connector = new MemoryConnector({ storage: {} });
+
+class User extends Model({
+  tableName: 'users',
+  connector,
+  init: (props: { name: string; age: number }) => props,
+}) {}
+
+await User.create({ name: 'Ada', age: 36 });
+await User.filterBy({ $gt: { age: 30 } }).count();   // 1
+```
+
+Swap the connector to switch backends — every Model feature (filters, transactions, aggregates, soft deletes, associations, schema DSL) goes through the same `Connector` interface.
+
+## Supported runtime
+
+- Node.js ≥ 22 (required by every package).
+- Pure ESM (`type: "module"`, `exports` field). Built with TypeScript 6 / `module: NodeNext`.
+- Browser support is limited to `@next-model/local-storage-connector`.
+
+## Development
+
+```sh
+pnpm install
+pnpm -r build
+pnpm typecheck
+pnpm -r coverage
+```
+
+CI matrix: Node 22 + 24 on every push, plus a real-database leg that boots Postgres 17 and MySQL 8 service containers and runs the knex-connector spec against each.
+
+## Contributing
+
+Open an issue or PR on [github.com/tamino-martinius/node-next-model](https://github.com/tamino-martinius/node-next-model). Each package keeps a rolling `vNext` section in its `HISTORY.md`; please append a one-line entry under the appropriate subheading when you ship a feature, fix or tooling change.
+
+## License
+
+MIT, copyright 2017–2026 Tamino Martinius.

--- a/packages/core/HISTORY.md
+++ b/packages/core/HISTORY.md
@@ -15,6 +15,7 @@ Rolling changelog for the next major release. Items below are appended in the or
 - Shared `runModelConformance` test helper (`@next-model/conformance`) gives every connector the same Model-level CRUD/Query/Transactions/Schema-DSL coverage. Wired into MemoryConnector, KnexConnector (sqlite/pg/mysql) and LocalStorageConnector specs. CI now runs `pnpm -r coverage` and each package's vitest config enforces coverage thresholds.
 - Schema DSL: `ColumnOptions.autoIncrement` now generates `t.increments(...)` on KnexConnector, so a table created via the DSL works with `KeyType.number` Models out of the box.
 - KnexConnector: `deleteAll`/`updateAll` no longer apply `limit`/`skip` to the underlying knex builder, fixing a sqlite "limit has no effect on a delete" error when the Model layer sets `limit: 1` on its single-row scope.
+- Repository documentation overhaul: new top-level `README.md`, fully rewritten READMEs for `knex-connector`, `data-api-connector`, `local-storage-connector`, and a new `migrations` README. Each connector README maps every relevant Model feature (filters, transactions, batchInsert, schema DSL, …) to that connector's specifics.
 
 ### Factory & configuration
 

--- a/packages/data-api-connector/README.md
+++ b/packages/data-api-connector/README.md
@@ -1,555 +1,104 @@
-# AWS Aurora Data API Connector
+# @next-model/data-api-connector
 
-Data API connector for [NextModel](https://github.com/tamino-martinius/node-next-model). [![Build Status](https://travis-ci.org/tamino-martinius/node-next-model-data-api-connector.svg?branch=master)](https://travis-ci.org/tamino-martinius/node-next-model-data-api-connector)
+Connector for [`@next-model/core`](../core) that targets the [AWS RDS Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html) — the HTTP-based query interface for Aurora Serverless v1 (PostgreSQL or MySQL flavour).
 
-Allows you to use **Knex** as Database Connector for NextModel:
+The connector uses [Knex 3](https://knexjs.org/) only as a query builder (`client: 'pg'`); it never opens a real DB connection. SQL strings + named parameters are produced locally and shipped to the Data API by an injectable client adapter, which keeps the package fully usable in cold-start-sensitive environments such as AWS Lambda.
 
-Supports:
+## Installation
 
-- AWS Data API for PostgreSQL
-- AWS Data API for MySQL (**not** tested)
+```sh
+pnpm add @next-model/data-api-connector
+```
 
-## Roadmap / Where can i contribute
+The default client wraps [`data-api-client`](https://www.npmjs.com/package/data-api-client) — install it if you don't bring your own:
 
-See [GitHub](https://github.com/tamino-martinius/node-next-model-data-api-connector/projects/1) project for current progress/tasks
+```sh
+pnpm add data-api-client
+```
 
-- Fix Typos
-- CI is missing for some Databases
-- Add more **examples**
-- Add **exists**, **join** and **subqueries**
-- There are already some **tests**, but not every test case is covered.
+## Constructing the connector
 
-## TOC
-
-- [AWS Aurora Data API Connector](#aws-aurora-data-api-connector)
-  - [Roadmap / Where can i contribute](#roadmap--where-can-i-contribute)
-  - [TOC](#toc)
-  - [Example](#example)
-    - [Create Connector](#create-connector)
-    - [Use Connector](#use-connector)
-  - [Build Queries](#build-queries)
-    - [Query](#query)
-    - [And](#and)
-    - [Or](#or)
-    - [Not](#not)
-    - [Nesting](#nesting)
-    - [Null](#null)
-    - [NotNull](#notnull)
-    - [Equation](#equation)
-    - [In](#in)
-    - [NotIn](#notin)
-    - [Between](#between)
-    - [NotBetween](#notbetween)
-    - [Raw](#raw)
-  - [Changelog](#changelog)
-
-## Example
-
-### Create Connector
-
-```js
-import DataApiConnector from '@next-model/data-api-connector';
+```ts
+import { DataApiConnector } from '@next-model/data-api-connector';
 
 const connector = new DataApiConnector({
-  secretArn: 'arn:aws:secretsmanager:us-east-1:XXXXXXXXXXXX:secret:mySecret',
-  resourceArn: 'arn:aws:rds:us-east-1:XXXXXXXXXXXX:cluster:my-cluster-name',
-  database: 'myDatabase', // default database
+  secretArn: process.env.AURORA_SECRET_ARN,
+  resourceArn: process.env.AURORA_CLUSTER_ARN,
+  database: 'app_production',
+  debug: false,
 });
 ```
 
-### Use Connector
+For tests or alternative transports, inject your own `DataApiClient` and skip the `data-api-client` dep entirely:
 
-The connector is used to connect your models to a database.
-
-```js
-const User = class User extends NextModel<UserSchema>() {
-  static get connector() {
-    return connector;
-  }
-
-  static get modelName() {
-    return 'User';
-  }
-
-  static get schema() {
-    return {
-      id: { type: 'integer' },
-      name: { type: 'string' },
-    };
-  }
-}
-```
-
-Create an base model with the connector to use it with multiple models.
-
-```js
-function BaseModel<T extends Identifiable>() {
-  return class extends NextModel<T>() {
-    static get connector() {
-      return new Connector<T>();
-    }
-  }
-};
-
-const User = class User extends BaseModel<UserSchema>() {
-  static get modelName() {
-    return 'User';
-  }
-
-  static get schema() {
-    return {
-      id: { type: 'integer' },
-      name: { type: 'string' },
-    };
-  }
-}
-
-const Address = class Address extends BaseModel<AddressSchema>() {
-  static get modelName() {
-    return 'Address';
-  }
-
-  static get schema() {
-    return {
-      id: { type: 'integer' },
-      street: { type: 'string' },
-    };
-  }
-}
-```
-
-## Build Queries
-
-This connector uses Knex to query SQL databases, but the query syntax is different from the Knex documentation. Samples of possible queries are listed below.
-
-### Query
-
-An object passed to `query` will filter for object property and value.
-
-```js
-User.query({ name: 'foo' });
-```
-
-```sql
-select "users".* from "users" where ("name" = 'foo')
-```
-
-If the Object has multiple properties the properties are connected with `and`.
-
-```js
-User.query({ name: 'foo', age: 18 });
-```
-
-```sql
-select "users".* from "users" where ("name" = 'foo' and "age" = 18)
-```
-
-An `query` connected with another `query`. A second query will encapsulate the query on the topmost layer.
-
-```js
-User.query({ name: 'foo', age: 18 }).query({ name: 'bar' });
-```
-
-```sql
-select "users".* from "users" where (("name" = 'foo' and "age" = 18) and ("name" = 'bar'))
-```
-
-### And
-
-Special properties are starting with an `$` sign. The `$and` property connects all values which are passed as `Array` with an SQL `and` operator.
-
-```js
-User.query({ $and: [{ name: 'foo' }] });
-```
-
-```sql
-select "users".* from "users" where (("name" = 'foo'))
-```
-
-```js
-User.query({ $and: [{ name: 'foo' }, { age: 18 }] });
-```
-
-```sql
-select "users".* from "users" where (("name" = 'foo') and ("age" = 18))
-```
-
-The special properties can also chained with other `where` queries.
-
-```js
-User.query({ $and: [{ name: 'foo' }, { age: 18 }] }).query({
-  $and: [{ name: 'bar' }, { age: 21 }],
-});
-```
-
-```sql
-select "users".* from "users" where ((("name" = 'foo') and ("age" = 18)) and (("name" = 'bar') and ("age" = 21)))
-```
-
-### Or
-
-The `$or` property works similar to the `$and` property and connects all values with `or`.
-
-```js
-User.query({ $or: [{ name: 'foo' }] });
-```
-
-```sql
-select "users".* from "users" where (("name" = 'foo'))
-```
-
-```js
-User.query({ $or: [{ name: 'foo' }, { name: 'bar' }] });
-```
-
-```sql
-select "users".* from "users" where (("name" = 'foo') or ("name" = 'bar'))
-```
-
-```js
-User.query({ $or: [{ name: 'foo' }, { age: 18 }] }).query({ $or: [{ name: 'bar' }, { age: 21 }] });
-```
-
-```sql
-select "users".* from "users" where ((("name" = 'foo') or ("age" = 18)) and (("name" = 'bar') or ("age" = 21)))
-```
-
-### Not
-
-The child object of an `$not` property will be inverted.
-
-```js
-User.query({
-  $not: {
-    name: 'foo',
+```ts
+const connector = new DataApiConnector({
+  client: {
+    async query(sql, params) { /* return { records, insertId, numberOfRecordsUpdated } */ },
+    async beginTransaction() { /* … */ },
+    async commitTransaction(id) { /* … */ },
+    async rollbackTransaction(id) { /* … */ },
   },
 });
 ```
 
-```sql
-select "users".* from "users" where (not ("name" = 'foo'))
-```
+## Wiring a Model
 
-```js
-User.query({
-  $not: {
-    name: 'foo',
-    age: 18,
-  },
+```ts
+import { Model } from '@next-model/core';
+import { DataApiConnector } from '@next-model/data-api-connector';
+
+const connector = new DataApiConnector({
+  secretArn: process.env.AURORA_SECRET_ARN,
+  resourceArn: process.env.AURORA_CLUSTER_ARN,
+  database: 'app_production',
 });
+
+class User extends Model({
+  tableName: 'users',
+  connector,
+  init: (props: { name: string; age: number }) => props,
+}) {}
 ```
 
-```sql
-select "users".* from "users" where (not ("name" = 'foo' and "age" = 18))
-```
-
-```js
-User.query({
-  $not: {
-    name: 'foo',
-    age: 18,
-  },
-}).query({
-  $not: {
-    name: 'bar',
-    age: 21,
-  },
-});
-```
-
-```sql
-select "users".* from "users" where ((not ("name" = 'foo' and "age" = 18)) and (not ("name" = 'bar' and "age" = 21)))
-```
-
-### Nesting
-
-The `$and`, `$or` and `$not` properties can be nested as deeply as needed.
-
-```js
-User.query({
-  $not: {
-    $or: [{ name: 'foo' }, { age: 21 }],
-  },
-});
-```
-
-```sql
-select "users".* from "users" where (not (("name" = 'foo') or ("age" = 21)))
-```
-
-```js
-User.query({
-  $not: {
-    $and: [{ name: 'foo' }, { $or: [{ age: 18 }, { age: 21 }] }],
-  },
-});
-```
+## Feature → connector specifics
 
-```sql
-select "users".* from "users" where (not (("name" = 'foo') and (("age" = 18) or ("age" = 21))))
-```
-
-### Null
-
-The `$null` property checks for unset columns and takes the column name as value.
-
-```js
-User.query({ $null: 'name' });
-```
-
-```sql
-select "users".* from "users" where ("name" is null)
-```
-
-### NotNull
-
-The `$notNull` property checks if an column is set and takes the column name as value.
-
-```js
-User.query({ $notNull: 'name' });
-```
+### Query compilation
 
-```sql
-select "users".* from "users" where ("name" is not null)
-```
-
-### Equation
-
-There are five different equation properties available.
-
-- `$eq` checks for equal
-- `$lt` checks for lower
-- `$gt` checks for greater
-- `$lte` checks for lower or equal
-- `$gte` checks for greater or equal
+Each scope is built with `knex({ client: 'pg' })` and converted to SQL + a parameter dict via `query.toSQL().toNative()`. The compiled SQL uses **named bindings** (`:p1, :p2, …`) — the format the Data API expects — and parameters are sent as a `{ name: value }` map.
 
-The property needs to be an object as value with the column name as key and the equation as value.
+### Filter operators
 
-```js
-User.query({ $lt: { age: 18 } });
-```
-
-```sql
-select "users".* from "users" where ("age" < 18)
-```
-
-```js
-User.query({ $lte: { age: 18 } });
-```
-
-```sql
-select "users".* from "users" where ("age" <= 18)
-```
+Same vocabulary as every other connector (`$and`, `$or`, `$not`, `$in`, `$notIn`, `$null`, `$notNull`, `$between`, `$notBetween`, `$gt/$gte/$lt/$lte`, `$like`, `$async`, `$raw`). All compile to PostgreSQL via knex' `pg` dialect and land at the Data API as parameterised SQL. `FilterError` is thrown for malformed special filters (multiple keys in `$gt`, empty `$in`, …).
 
-_Please note:_ Just one propery is allowed!
+### `execute(query, bindings)`
 
-This is invalid:
+Bindings can be a positional array or a named dict; the connector forwards them as-is. Result records are returned as a flat `Dict<any>[]`.
 
-```js
-User.query({
-  $lt: {
-    age: 18,
-    size: 180,
-  },
-});
-```
+### Transactions
 
-This is valid:
+`connector.transaction(fn)` wraps the callback in `beginTransaction` / `commitTransaction` (or `rollbackTransaction` on throw), pinning the transaction id to `activeTransactionId` so any nested calls participate. Re-entrant transactions join the outer one — there are no savepoints, so an inner throw rolls back the whole outer transaction.
 
-```js
-User.query({ $and: [{ $lt: { age: 18 } }, { $lt: { size: 180 } }] });
-```
+### `batchInsert`
 
-```sql
-select "users".* from "users" where ("age" < 18 and "size" < 180)
-```
+The Data API does not return inserted rows. The connector inserts items one at a time, capturing `insertId` per row, then re-fetches the inserted records by primary key. For `KeyType.manual` it skips the `insertId` step and re-fetches by the caller-supplied key. `PersistenceError` is raised if a re-fetch turns up empty.
 
-### In
+### `updateAll` / `deleteAll`
 
-The `$in` property needs an object as value with the column name as key and the `Array` of values as value.
+Both build a SELECT for the affected rows first (so the methods can return them), then issue the mutation against the same WHERE clause without any `LIMIT` / `OFFSET` — Aurora Postgres rejects `DELETE … LIMIT`, so the scope's limit/skip are ignored at this layer.
 
-```js
-User.query({
-  $in: {
-    name: ['foo', 'bar'],
-  },
-});
-```
+### Schema DSL
 
-```sql
-select "users".* from "users" where ("name" in ('foo', 'bar'))
-```
+`createTable`/`dropTable`/`hasTable` map the [core schema DSL](../core/README.md) onto Postgres DDL via knex' `pg` schema builder; the resulting DDL is executed through the Data API. `defineTable` is used to validate column definitions before generating SQL.
 
-_Please note:_ Just one propery is allowed!
+### Auto-increment
 
-This is invalid:
+Set `{ autoIncrement: true }` on an integer column to get a Postgres `SERIAL` (knex `table.increments(name)`). Required when you use `KeyType.number` (the default) — otherwise insert SQL provides no value for the PK column.
 
-```js
-User.query({
-  $in: {
-    name: ['foo', 'bar'],
-    age: [18, 19, 20, 21],
-  },
-});
-```
+## Aurora MySQL Data API
 
-This is valid:
-
-```js
-User.query({ $and: [{ $in: { name: ['foo', 'bar'] } }, { $in: { age: [18, 19, 20, 21] } }] });
-```
-
-```sql
-select "users".* from "users" where ("name" in ('foo', 'bar') and "age" in (18, 19, 20, 21))
-```
-
-### NotIn
-
-`$notIn` works same as `$in` but inverts the result.
-
-```js
-User.query({
-  $notIn: {
-    name: ['foo', 'bar'],
-  },
-});
-```
-
-```sql
-select "users".* from "users" where ("name" not in ('foo', 'bar'))
-```
-
-_Please note:_ Just one propery is allowed!
-
-This is invalid:
-
-```js
-User.query({
-  $notIn: {
-    name: ['foo', 'bar'],
-    age: [18, 19, 20, 21],
-  },
-});
-```
-
-This is valid:
-
-```js
-User.query({ $and: [{ $notIn: { name: ['foo', 'bar'] } }, { $notIn: { age: [18, 19, 20, 21] } }] });
-```
-
-```sql
-select "users".* from "users" where ("name" not in ('foo', 'bar') and "age" not in (18, 19, 20, 21))
-```
-
-### Between
-
-The `$between` property needs an object as value with the column name as key and an `Array` with the min and max values as value.
-
-```js
-User.query({
-  $between: {
-    age: [18, 21],
-  },
-});
-```
-
-```sql
-select "users".* from "users" where ("age" between 18 and 21)
-```
-
-_Please note:_ Just one propery is allowed!
-
-This is invalid:
-
-```js
-User.query({
-  $between: {
-    age: [18, 21],
-    size: [160, 185],
-  },
-});
-```
-
-This is valid:
-
-```js
-User.query({ $and: [{ $between: { age: [18, 21] } }, { $between: { size: [160, 185] } }] });
-```
-
-```sql
-select "users".* from "users" where ("age" between 18 and 21 and "size" between 160 and 165)
-```
-
-### NotBetween
-
-`$notBetween` works same as `$between` but inverts the result.
-
-```js
-User.query({
-  $notBetween: {
-    age: [18, 21],
-  },
-});
-```
-
-```sql
-select "users".* from "users" where ("age" not between 18 and 21)
-```
-
-_Please note:_ Just one propery is allowed!
-
-This is invalid:
-
-```js
-User.query({
-  $notBetween: {
-    age: [18, 21],
-    size: [160, 185],
-  },
-});
-```
-
-This is valid:
-
-```js
-User.query({ $and: [{ $notBetween: { age: [18, 21] } }, { $notBetween: { size: [160, 185] } }] });
-```
-
-```sql
-select "users".* from "users" where ("age" not between 18 and 21 and "size" not between 160 and 165)
-```
-
-### Raw
-
-The `$raw` property allows to write custom and database specific queries. Pass queries as object, where key is the query and value are the bindings.
-
-_Note: See [Knex documentation](http://knexjs.org/#Raw-Bindings) for more details about bindings._
-
-```js
-User.query({
-  $raw: {
-    $query: 'age = ?',
-    $bindings: 18,
-  },
-});
-```
-
-```js
-User.query({
-  $raw: {
-    $query: 'age = :age',
-    $bindings: { age: 18 },
-  },
-});
-```
-
-```sql
-select "users".* from "users" where ("age" = 18)
-```
+The compiled SQL targets PostgreSQL syntax. If you point the connector at a MySQL Aurora cluster you'll need to verify quoting/keywords match your queries — this path is not part of CI.
 
 ## Changelog
 
-See [history](HISTORY.md) for more details.
-
-- `1.0.0` **2020-01-06** Initial Release
+See [`HISTORY.md`](./HISTORY.md).

--- a/packages/knex-connector/README.md
+++ b/packages/knex-connector/README.md
@@ -1,615 +1,158 @@
-# KnexConnector
+# @next-model/knex-connector
 
-SQL connector for [NextModel](https://github.com/tamino-martinius/node-next-model) package using [Knex](http://knexjs.org/). [![Build Status](https://travis-ci.org/tamino-martinius/node-next-model-knex-connector.svg?branch=master)](https://travis-ci.org/tamino-martinius/node-next-model-knex-connector)
+SQL connector for [`@next-model/core`](../core), backed by [Knex 3](https://knexjs.org/).
 
-Allows you to use **Knex** as Database Connector for NextModel:
+Tested in CI against:
 
-Supports:
+- **sqlite3** — in-memory, every push.
+- **PostgreSQL 17** — service container, every push.
+- **MySQL 8** — service container, every push.
 
-* pg
-* sqlite3
-* mysql
-* mysql2
-* mariasql (**not** tested)
-* strong-oracle (**not** tested)
-* oracle
-* mssql (**not** tested)
+Should also work against any other Knex client (MariaDB, Oracle, MSSQL, Redshift) but those are not part of the CI matrix.
 
-## Roadmap / Where can i contribute
+## Installation
 
-See [GitHub](https://github.com/tamino-martinius/node-next-model-knex-connector/projects/1) project for current progress/tasks
+```sh
+pnpm add @next-model/knex-connector knex
+pnpm add -D sqlite3        # or pg / mysql2 / tedious / oracledb …
+```
 
-* Fix Typos
-* CI is missing for some Databases
-* Add more **examples**
-* Add **exists**, **join** and **subqueries**
-* There are already some **tests**, but not every test case is covered.
+`knex` is a runtime dependency; the actual driver (`pg`, `mysql2`, `sqlite3`, …) you choose is yours to install per the database you target.
 
-## TOC
+## Constructing the connector
 
-* [Example](#example)
-  * [Create Connector](#create-connector)
-  * [Use Connector](#use-connector)
-* [Build Queries](#build-queries)
-  * [query](#query)
-  * [find](#find)
-  * [And](#and)
-  * [Or](#or)
-  * [Not](#not)
-  * [Nesting](#nesting)
-  * [Null](#null)
-  * [NotNull](#notnull)
-  * [Equation](#equation)
-  * [In](#in)
-  * [NotIn](#notin)
-  * [Between](#between)
-  * [NotBetween](#notbetween)
-  * [Raw](#raw)
-  * [Execute](#execute)
-* [Changelog](#changelog)
+The constructor takes the same options object as `knex({...})`:
 
-## Example
+```ts
+import { KnexConnector } from '@next-model/knex-connector';
 
-### Create Connector
-
-Constructor options are passed to [Knex](http://knexjs.org/).
-
-Its recommended to set `useNullAsDefault` to true unless all model attributes are set.
-
-The client parameter is required and determines which client adapter will be used with the library.
-
-The connection options are passed directly to the appropriate database client to create the connection, and may be either an object, or a connection string
-
-~~~js
-import KnexConnector from '@next-model/knex-connector';
-
-const connector = new KnexConnector({
-  client: 'mysql',
-  connection: {
-    host : '127.0.0.1',
-    user : 'your_database_user',
-    password : 'your_database_password',
-    database : 'myapp_test'
-  },
+// sqlite (file or :memory:)
+const sqlite = new KnexConnector({
+  client: 'sqlite3',
+  connection: { filename: ':memory:' },
+  useNullAsDefault: true,
 });
-~~~
 
-~~~js
-import KnexConnector from '@next-model/knex-connector';
+// Postgres
+const pg = new KnexConnector({
+  client: 'pg',
+  connection: process.env.DATABASE_URL,
+});
+
+// MySQL
+const mysql = new KnexConnector({
+  client: 'mysql2',
+  connection: 'mysql://root:secret@127.0.0.1:3306/myapp',
+  pool: { min: 1, max: 10 },
+});
+```
+
+The underlying knex instance is exposed as `connector.knex` if you need to drop down to raw query-building or call `connector.knex.destroy()` on shutdown.
+
+## Wiring a Model
+
+```ts
+import { Model } from '@next-model/core';
+import { KnexConnector } from '@next-model/knex-connector';
 
 const connector = new KnexConnector({
   client: 'pg',
-  connection: process.env.PG_CONNECTION_STRING,
-  searchPath: 'knex,public'
+  connection: process.env.DATABASE_URL,
 });
-~~~
 
-_Note: When you use the SQLite3 adapter, there is a filename required, not a network connection. For example:_
+class User extends Model({
+  tableName: 'users',
+  connector,
+  init: (props: { name: string; age: number }) => props,
+}) {}
+```
 
-~~~js
-import KnexConnector from '@next-model/knex-connector';
+Every Model feature (filters, aggregates, transactions, soft deletes, associations, schema DSL) flows through the `Connector` interface — so the rest of your code is identical regardless of which driver you picked.
 
-const connector = new KnexConnector({
-  client: 'sqlite3',
-  connection: {
-    filename: "./mydb.sqlite"
-  }
-});
-~~~
+## Feature → connector specifics
 
-### Use Connector
+### Schema DSL → SQL DDL
 
-The connector is used to connect your models to a database.
+`connector.createTable(name, t => …)` accepts the [core schema DSL](../core/README.md). The connector translates each column kind to the matching knex schema-builder method:
 
-~~~js
-const User = class User extends NextModel<UserSchema>() {
-  static get connector() {
-    return connector;
-  }
+| Core DSL                         | Knex call                |
+|----------------------------------|--------------------------|
+| `t.integer('id', { autoIncrement: true })` | `table.increments('id')` |
+| `t.string('name')`               | `table.string('name', limit ?? 255)` |
+| `t.text('body')`                 | `table.text('body')`     |
+| `t.bigint('count')`              | `table.bigInteger('count')` |
+| `t.float('rate')`                | `table.float('rate')`    |
+| `t.decimal('price', { precision, scale })` | `table.decimal('price', precision, scale)` |
+| `t.boolean('active')`            | `table.boolean('active')` |
+| `t.date('day')`                  | `table.date('day')`      |
+| `t.datetime / t.timestamp(...)`  | `table.timestamp(name)`  |
+| `t.json('payload')`              | `table.json('payload')`  |
+| `t.timestamps()`                 | two `timestamp` columns + `now()` defaults |
+| `t.index(cols, { unique })`      | `table.index` / `table.unique` |
 
-  static get modelName() {
-    return 'User';
-  }
+`{ default: 'currentTimestamp' }` becomes `defaultTo(knex.fn.now())`. Every other `default:` value is passed through to `defaultTo()` verbatim.
 
-  static get schema() {
-    return {
-      id: { type: 'integer' },
-      name: { type: 'string' },
-    };
-  }
-}
-~~~
+### Filter operators → WHERE clauses
 
-Create an base model with the connector to use it with multiple models.
+| Filter | SQL produced |
+|--------|--------------|
+| `{ name: 'Ada' }` | `name = ?` |
+| `{ $or: [a, b] }` | `(... ) OR (...)` (recursive) |
+| `{ $not: f }`     | `NOT (...)` |
+| `{ $in: { col: [...] } }`  | `col IN (?, ?, …)` |
+| `{ $notIn: { col: [...] } }` | `col NOT IN (?, ?, …)` |
+| `{ $null: 'col' }` / `{ $notNull: 'col' }` | `col IS NULL` / `col IS NOT NULL` |
+| `{ $between: { col: { from, to } } }` | `col BETWEEN ? AND ?` |
+| `{ $gt / $gte / $lt / $lte: { col: v } }` | `col > ?` etc. |
+| `{ $like: { col: 'pat%' } }` | `col LIKE ?` (case sensitivity follows the driver — Postgres is case-sensitive, MySQL/SQLite default to insensitive). |
+| `{ $async: Promise<Filter> }` | the inner filter is `await`-ed and re-applied recursively. |
+| `{ $raw: { $query, $bindings } }` | `whereRaw($query, $bindings)`. `?` placeholders are translated to driver-specific positional markers (Postgres `$1`, MySQL `?`). |
 
-~~~js
-function BaseModel<T extends Identifiable>() {
-  return class extends NextModel<T>() {
-    static get connector() {
-      return new Connector<T>();
-    }
-  }
-};
+`FilterError` is thrown for malformed special filters (multiple keys in `$gt`, empty `$in`, …).
 
-const User = class User extends BaseModel<UserSchema>() {
-  static get modelName() {
-    return 'User';
-  }
+### Aggregates
 
-  static get schema() {
-    return {
-      id: { type: 'integer' },
-      name: { type: 'string' },
-    };
-  }
-}
+`connector.aggregate(scope, kind, key)` issues a single `SELECT kind(key) AS kind_result` query. The result is coerced via `Number()`, so Postgres' `AVG → numeric (string)` is normalised to a JS number.
 
-const Address = class Address extends BaseModel<AddressSchema>() {
-  static get modelName() {
-    return 'Address';
-  }
+### `execute(query, bindings)`
 
-  static get schema() {
-    return {
-      id: { type: 'integer' },
-      street: { type: 'string' },
-    };
-  }
-}
-~~~
+Runs raw SQL via `knex.raw` (joining the active transaction if any). The result is normalised so callers always see a flat `Dict<any>[]`:
 
-## Build Queries
+| Driver          | Source                  |
+|-----------------|-------------------------|
+| sqlite3         | `result` itself         |
+| pg / postgres   | `result.rows`           |
+| mysql / mysql2  | `result[0]` (knex returns `[rows, fields]`) |
 
-This connector uses Knex to query SQL databases, but the query syntax is different from the Knex documentation. Samples of possible queries are listed below.
+### Transactions
 
-### Query
+`connector.transaction(fn)` opens a real `knex.transaction` and pins it to `activeTransaction` so every nested call (including schema operations and `execute`) participates. Re-entrant calls *join* the outer transaction rather than nesting savepoints — the inner callback runs inside the outer one and a thrown error rolls the entire outer back. Errors thrown inside `fn` propagate after the rollback.
 
-An object passed to `query` will filter for object property and value.
+### `batchInsert`
 
-~~~js
-User.query({ name: 'foo' });
-~~~
+The connector picks a strategy per driver because not every driver supports `RETURNING *`:
 
-~~~sql
-select "users".* from "users" where ("name" = 'foo')
-~~~
+- **sqlite3** — inserts items one-by-one, then re-fetches each by primary key.
+- **pg** — `INSERT … RETURNING *` returns the full inserted rows in one round-trip.
+- **mysql / mysql2** — bulk `INSERT` returns only the first auto-increment id; the connector expands it to consecutive ids (safe under InnoDB's contiguous lock for a single statement) and re-fetches all rows in one `whereIn(id)` query.
+- **`KeyType.manual`** — short-circuits the re-fetch and echoes the items back as-is.
 
-If the Object has multiple properties the properties are connected with `and`.
+### `updateAll` / `deleteAll`
 
-~~~js
-User.query({ name: 'foo', age: 18 });
-~~~
+Both build the WHERE clause directly from `scope.filter` and ignore `scope.limit` / `scope.skip`, which sqlite rejects (`limit has no effect on a delete/update`). The current row set is captured by an explicit `query()` call before the mutation so the methods can return the affected rows even when the driver lacks `RETURNING`.
 
-~~~sql
-select "users".* from "users" where ("name" = 'foo' and "age" = 18)
-~~~
+## Test matrix
 
-An `query` connected with another `query`. A second query will encapsulate the query on the topmost layer.
+The package's spec is driver-agnostic and selects its backend via env vars:
 
-~~~js
-User.query({ name: 'foo', age: 18 }).query({ name: 'bar' });
-~~~
+```sh
+KNEX_TEST_CLIENT=sqlite3 pnpm test               # default
+KNEX_TEST_CLIENT=pg DATABASE_URL=postgres://… pnpm test
+KNEX_TEST_CLIENT=mysql2 DATABASE_URL=mysql://… pnpm test
+```
 
-~~~sql
-select "users".* from "users" where (("name" = 'foo' and "age" = 18) and ("name" = 'bar'))
-~~~
-
-### And
-
-Special properties are starting with an `$` sign. The `$and` property connects all values which are passed as `Array` with an SQL `and` operator.
-
-~~~js
-User.query({ $and: [
-  { name: 'foo' },
-]});
-~~~
-
-~~~sql
-select "users".* from "users" where (("name" = 'foo'))
-~~~
-
-~~~js
-User.query({ $and: [
-  { name: 'foo' },
-  { age: 18 },
-]});
-~~~
-
-~~~sql
-select "users".* from "users" where (("name" = 'foo') and ("age" = 18))
-~~~
-
-The special properties can also chained with other `where` queries.
-
-~~~js
-User.query({ $and: [
-  { name: 'foo' },
-  { age: 18 },
-]}).query({ $and: [
-  { name: 'bar' },
-  { age: 21 },
-]});
-~~~
-
-~~~sql
-select "users".* from "users" where ((("name" = 'foo') and ("age" = 18)) and (("name" = 'bar') and ("age" = 21)))
-~~~
-
-### Or
-
-The `$or` property works similar to the `$and` property and connects all values with `or`.
-
-~~~js
-User.query({ $or: [
-  { name: 'foo' },
-]});
-~~~
-
-~~~sql
-select "users".* from "users" where (("name" = 'foo'))
-~~~
-
-~~~js
-User.query({ $or: [
-  { name: 'foo' },
-  { name: 'bar' },
-]});
-~~~
-
-~~~sql
-select "users".* from "users" where (("name" = 'foo') or ("name" = 'bar'))
-~~~
-
-~~~js
-User.query({ $or: [
-  { name: 'foo' },
-  { age: 18 },
-]}).query({ $or: [
-  { name: 'bar' },
-  { age: 21 },
-]});
-~~~
-
-~~~sql
-select "users".* from "users" where ((("name" = 'foo') or ("age" = 18)) and (("name" = 'bar') or ("age" = 21)))
-~~~
-
-### Not
-
-The child object of an `$not` property will be inverted.
-
-~~~js
-User.query({ $not: {
-  name: 'foo'
-}});
-~~~
-
-~~~sql
-select "users".* from "users" where (not ("name" = 'foo'))
-~~~
-
-~~~js
-User.query({ $not: {
-  name: 'foo',
-  age: 18,
-}});
-~~~
-
-~~~sql
-select "users".* from "users" where (not ("name" = 'foo' and "age" = 18))
-~~~
-
-~~~js
-User.query({ $not: {
-  name: 'foo',
-  age: 18,
-}}).query({ $not: {
-  name: 'bar',
-  age: 21,
-}});
-~~~
-
-~~~sql
-select "users".* from "users" where ((not ("name" = 'foo' and "age" = 18)) and (not ("name" = 'bar' and "age" = 21)))
-~~~
-
-### Nesting
-
-The `$and`, `$or` and `$not` properties can be nested as deeply as needed.
-
-~~~js
-User.query({ $not: {
-  $or: [
-    { name: 'foo' },
-    { age: 21 },
-  ],
-}});
-~~~
-
-~~~sql
-select "users".* from "users" where (not (("name" = 'foo') or ("age" = 21)))
-~~~
-
-~~~js
-User.query({ $not: {
-  $and: [
-    { name: 'foo' },
-    { $or: [
-      { age: 18 },
-      { age: 21 },
-    ]},
-  ],
-}});
-~~~
-
-~~~sql
-select "users".* from "users" where (not (("name" = 'foo') and (("age" = 18) or ("age" = 21))))
-~~~
-
-### Null
-
-The `$null` property checks for unset columns and takes the column name as value.
-
-~~~js
-User.query({ $null: 'name' });
-~~~
-
-~~~sql
-select "users".* from "users" where ("name" is null)
-~~~
-
-### NotNull
-
-The `$notNull` property checks if an column is set and takes the column name as value.
-
-~~~js
-User.query({ $notNull: 'name' });
-~~~
-
-~~~sql
-select "users".* from "users" where ("name" is not null)
-~~~
-
-### Equation
-
-There are five different equation properties available.
-
-* `$eq` checks for equal
-* `$lt` checks for lower
-* `$gt` checks for greater
-* `$lte` checks for lower or equal
-* `$gte` checks for greater or equal
-
-The property needs to be an object as value with the column name as key and the equation as value.
-
-~~~js
-User.query({ $lt: { age: 18 } });
-~~~
-
-~~~sql
-select "users".* from "users" where ("age" < 18)
-~~~
-
-~~~js
-User.query({ $lte: { age: 18 } });
-~~~
-
-~~~sql
-select "users".* from "users" where ("age" <= 18)
-~~~
-
-*Please note:* Just one propery is allowed!
-
-This is invalid:
-
-~~~js
-User.query({ $lt: {
-  age: 18,
-  size: 180,
-}});
-~~~
-
-This is valid:
-
-~~~js
-User.query({ $and: [
-  { $lt: { age: 18 } },
-  { $lt: { size: 180 } },
-]});
-~~~
-
-~~~sql
-select "users".* from "users" where ("age" < 18 and "size" < 180)
-~~~
-
-### In
-
-The `$in` property needs an object as value with the column name as key and the `Array` of values as value.
-
-~~~js
-User.query({ $in: {
-  name: ['foo', 'bar'],
-}});
-~~~
-
-~~~sql
-select "users".* from "users" where ("name" in ('foo', 'bar'))
-~~~
-
-*Please note:* Just one propery is allowed!
-
-This is invalid:
-
-~~~js
-User.query({ $in: {
-  name: ['foo', 'bar'],
-  age: [18, 19, 20, 21],
-}});
-~~~
-
-This is valid:
-
-~~~js
-User.query({ $and: [
-  { $in: { name: ['foo', 'bar'] } },
-  { $in: { age: [18, 19, 20, 21] } },
-]});
-~~~
-
-~~~sql
-select "users".* from "users" where ("name" in ('foo', 'bar') and "age" in (18, 19, 20, 21))
-~~~
-
-### NotIn
-
-`$notIn` works same as `$in` but inverts the result.
-
-~~~js
-User.query({ $notIn: {
-  name: ['foo', 'bar'],
-}});
-~~~
-
-~~~sql
-select "users".* from "users" where ("name" not in ('foo', 'bar'))
-~~~
-
-*Please note:* Just one propery is allowed!
-
-This is invalid:
-
-~~~js
-User.query({ $notIn: {
-  name: ['foo', 'bar'],
-  age: [18, 19, 20, 21],
-}});
-~~~
-
-This is valid:
-
-~~~js
-User.query({ $and: [
-  { $notIn: { name: ['foo', 'bar'] } },
-  { $notIn: { age: [18, 19, 20, 21] } },
-]});
-~~~
-
-~~~sql
-select "users".* from "users" where ("name" not in ('foo', 'bar') and "age" not in (18, 19, 20, 21))
-~~~
-
-### Between
-
-The `$between` property needs an object as value with the column name as key and an  `Array` with the min and max values as value.
-
-~~~js
-User.query({ $between: {
-  age: [18, 21],
-}});
-~~~
-
-~~~sql
-select "users".* from "users" where ("age" between 18 and 21)
-~~~
-
-*Please note:* Just one propery is allowed!
-
-This is invalid:
-
-~~~js
-User.query({ $between: {
-  age: [18, 21],
-  size: [160, 185],
-}});
-~~~
-
-This is valid:
-
-~~~js
-User.query({ $and: [
-  { $between: { age: [18, 21] } },
-  { $between: { size: [160, 185] } },
-]});
-~~~
-
-~~~sql
-select "users".* from "users" where ("age" between 18 and 21 and "size" between 160 and 165)
-~~~
-
-### NotBetween
-
-`$notBetween` works same as `$between` but inverts the result.
-
-~~~js
-User.query({ $notBetween: {
-  age: [18, 21],
-}});
-~~~
-
-~~~sql
-select "users".* from "users" where ("age" not between 18 and 21)
-~~~
-
-*Please note:* Just one propery is allowed!
-
-This is invalid:
-
-~~~js
-User.query({ $notBetween: {
-  age: [18, 21],
-  size: [160, 185],
-}});
-~~~
-
-This is valid:
-
-~~~js
-User.query({ $and: [
-  { $notBetween: { age: [18, 21] } },
-  { $notBetween: { size: [160, 185] } },
-]});
-~~~
-
-~~~sql
-select "users".* from "users" where ("age" not between 18 and 21 and "size" not between 160 and 165)
-~~~
-
-### Raw
-
-The `$raw` property allows to write custom and database specific queries. Pass queries as object, where key is the query and value are the bindings.
-
-_Note: See [Knex documentation](http://knexjs.org/#Raw-Bindings) for more details about bindings._
-
-~~~js
-User.query({ $raw: {
-  $query: 'age = ?',
-  $bindings: 18,
-}});
-~~~
-
-~~~js
-User.query({ $raw: {
-  $query: 'age = :age',
-  $bindings: { age: 18 },
-}});
-~~~
-
-~~~sql
-select "users".* from "users" where ("age" = 18)
-~~~
+CI runs all three.
 
 ## Changelog
 
-See [history](HISTORY.md) for more details.
-
-* `1.0.0` **2018-xx-xx** Complete rewrite based on TypeScript
-* `0.3.3` **2017-04-05** Updated next-model dependency
-* `0.3.2` **2017-02-28** Updated next-model dependency
-* `0.3.1` **2017-02-27** Updated next-model dependency
-* `0.3.0` **2017-02-22** Added Node 4 Support
-* `0.2.0` **2017-02-21** Added new query types
-* `0.1.0` **2017-02-18** Used next-model from npm instead of Github repo
-* `0.0.4` **2017-02-16** Updated to NextModel v0.0.4
-* `0.0.3` **2017-02-12** Added CI
-* `0.0.2` **2017-02-12** Added more complex query types
-* `0.0.1` **2017-02-05** First release compatible with NextModel 0.0.1
+See [`HISTORY.md`](./HISTORY.md).

--- a/packages/local-storage-connector/README.md
+++ b/packages/local-storage-connector/README.md
@@ -1,426 +1,84 @@
-# NextModelLocalStorageConnector
+# @next-model/local-storage-connector
 
-LocalStorage connector for [NextModel](https://github.com/tamino-martinius/node-next-model) package.
+Browser `localStorage` connector for [`@next-model/core`](../core).
 
- [![Build Status](https://travis-ci.org/tamino-martinius/node-next-model-local-storage-connector.svg?branch=master)](https://travis-ci.org/tamino-martinius/node-next-model-local-storage-connector)
+`LocalStorageConnector` extends `MemoryConnector`, so every behaviour you get from the in-memory store (filter operators, ordering, aggregates, transactions with rollback, schema DSL, JS-expression `execute`) carries over verbatim. The only differences are persistence and id management.
 
-Special keys for queries:
-* $and
-* $or
-* $not
-* $null
-* $notNull
-* $in
-* $notIn
-* $between
-* $notBetween
-* $eq
-* $lt
-* $lte
-* $gt
-* $gte
-* $match
-* $filter
+## Installation
 
-### Roadmap / Where can i contribute
+```sh
+pnpm add @next-model/local-storage-connector
+```
 
-See [GitHub project](https://github.com/tamino-martinius/node-next-model-local-storage-connector/projects/1) for current progress/tasks
+No other peer dependencies.
 
-* Fix Typos
-* Add more **examples**
-* Add **exists**, **join** and **subqueries**
-* There are already some **tests**, but not every test case is covered.
+## Constructing the connector
 
-## TOC
+```ts
+import { LocalStorageConnector } from '@next-model/local-storage-connector';
 
-* [Example](#example)
-  * [Create Connector](#create-connector)
-  * [Use Connector](#use-connector)
-* [Build Queries](#build-queries)
-  * [Where](#where)
-  * [And](#and)
-  * [Or](#or)
-  * [Not](#not)
-  * [Nesting](#nesting)
-  * [Null](#null)
-  * [NotNull](#notnull)
-  * [Equation](#equation)
-  * [In](#in)
-  * [NotIn](#notin)
-  * [Between](#between)
-  * [NotBetween](#notbetween)
-  * [Match](#match)
-  * [Filter](#filter)
-* [Changelog](#changelog)
+// Browser: picks up globalThis.localStorage automatically
+const connector = new LocalStorageConnector();
 
-## Example
+// With an injected store (Node tests, sandboxed environments)
+import { MemoryLocalStorage } from '@next-model/local-storage-connector/dist/__mocks__/MemoryLocalStorage.js';
+const connector = new LocalStorageConnector({ localStorage: new MemoryLocalStorage() });
 
-### Create Connector
-
-The constructor allows to pass an prefix or postfix.
-
-~~~js
-const connector = new NextModelKnexConnector({
-  prefix: 'app_',
+// Namespacing keys
+const connector = new LocalStorageConnector({
+  prefix: 'app:',
+  suffix: ':v2',
 });
-~~~
-
-~~~js
-const connector = new NextModelKnexConnector({
-  postfix: '_test',
-});
-~~~
-
-~~~js
-const connector = new NextModelKnexConnector({
-  prefix: 'app_',
-  postfix: '_test',
-});
-~~~
-
-### Use Connector
-
-The connector is used to connect your models to a database.
-
-~~~js
-const User = class User extends NextModel {
-  static get connector() {
-    return connector;
-  }
-
-  static get modelName() {
-    return 'User';
-  }
-
-  static get schema() {
-    return {
-      id: { type: 'integer' },
-      name: { type: 'string' },
-    };
-  }
-}
-~~~
-
-Create an base model with the connector to use it with multiple models.
-
-~~~js
-const BaseModel = class BaseModel extends NextModel {
-  static get connector() {
-    return connector;
-  }
-});
-
-const User = class User extends BaseModel {
-  static get modelName() {
-    return 'User';
-  }
-
-  static get schema() {
-    return {
-      id: { type: 'integer' },
-      name: { type: 'string' },
-    };
-  }
-}
-
-const Address = class Address extends BaseModel {
-  static get modelName() {
-    return 'Address';
-  }
-
-  static get schema() {
-    return {
-      id: { type: 'integer' },
-      street: { type: 'string' },
-    };
-  }
-}
-~~~
-
-## Build Queries
-
-This connector allows to filter the data. Samples of possible queries are listed below.
-
-### Where
-
-An object passed as `where` clause will query for object property and value.
-
-~~~js
-User.where({ name: 'foo' });
-~~~
-
-If the Object has multiple properties the properties are connected with `and`.
-
-~~~js
-User.where({ name: 'foo', age: 18 });
-~~~
-
-An `where` query can be connected with another `where` or an `orWhere`. A second query will encapsulate the query on the topmost layer.
-
-~~~js
-User.where({ name: 'foo', age: 18 }).orWhere({ name: 'bar' });
-~~~
-
-### And
-
-Special properties are starting with an `$` sign. The `$and` property connects all values which are passed as `Array` with an SQL `and` operator.
-
-~~~js
-User.where({ $and: [
-  { name: 'foo' },
-]});
-~~~
-
-~~~js
-User.where({ $and: [
-  { name: 'foo' },
-  { age: 18 },
-]});
-~~~
-
-The special properties can also chained with other `where` queries.
-
-~~~js
-User.where({ $and: [
-  { name: 'foo' },
-  { age: 18 },
-]}).orWhere({ $and: [
-  { name: 'bar' },
-  { age: 21 },
-]});
-~~~
-
-### Or
-
-The `$or` property works similar to the `$and` property and connects all values with `or`.
-
-~~~js
-User.where({ $or: [
-  { name: 'foo' },
-]});
-~~~
-
-~~~js
-User.where({ $or: [
-  { name: 'foo' },
-  { name: 'bar' },
-]});
-~~~
-
-~~~js
-User.where({ $or: [
-  { name: 'foo' },
-  { age: 18 },
-]}).where({ $or: [
-  { name: 'bar' },
-  { age: 21 },
-]});
-~~~
-
-### Not
-
-The child object of an `$not` property will be inverted.
-
-~~~js
-User.where({ $not: {
-  name: 'foo'
-}});
-~~~
-
-~~~js
-User.where({ $not: {
-  name: 'foo',
-  age: 18,
-}});
-~~~
-
-~~~js
-User.where({ $not: {
-  name: 'foo',
-  age: 18,
-}}).where({ $not: {
-  name: 'bar',
-  age: 21,
-}});
-~~~
-
-### Nesting
-
-The `$and`, `$or` and `$not` properties can be nested as deeply as needed.
-
-~~~js
-User.where({ $not: {
-  $or: [
-    { name: 'foo' },
-    { age: 21 },
-  ],
-}});
-~~~
-
-~~~js
-User.where({ $not: {
-  $and: [
-    { name: 'foo' },
-    { $or: [
-      { age: 18 },
-      { age: 21 },
-    ]},
-  ],
-}});
-~~~
-
-### Null
-
-The `$null` property checks for unset columns and takes the column name as value.
-
-~~~js
-User.where({ $null: 'name' });
-~~~
-
-### NotNull
-
-The `$notNull` property checks if an column is set and takes the column name as value.
-
-~~~js
-User.where({ $notNull: 'name' });
-~~~
-
-### Equation
-
-There are five different equation properties available.
-* `$eq` checks for equal
-* `$lt` checks for lower
-* `$gt` checks for greater
-
-`$lt`, `$gt` also allows equal values.
-
-The property needs to be an object as value with the column name as key and the equation as value.
-
-~~~js
-User.where({ $lt: { age: 18 } });
-~~~
-
-~~~js
-User.where({ $lt: { age: 18, size: 180 } });
-~~~
-
-~~~js
-User.where({ $lte: { age: 18 } });
-~~~
-
-~~~js
-User.where({ $lte: { age: 18, size: 180 } });
-~~~
-
-### In
-
-The `$in` property needs an object as value with the column name as key and the `Array` of values as value.
-
-~~~js
-User.where({ $in: {
-  name: ['foo', 'bar'],
-}});
-~~~
-
-If multiple properties are present they get connected by an `and` operator.
-
-~~~js
-User.where({ $in: {
-  name: ['foo', 'bar'],
-  age: [18, 19, 20, 21],
-}});
-~~~
-
-### NotIn
-
-`$notIn` works same as `$in` but inverts the result.
-
-~~~js
-User.where({ $notIn: {
-  name: ['foo', 'bar'],
-}});
-~~~
-
-~~~js
-User.where({ $notIn: {
-  name: ['foo', 'bar'],
-  age: [18, 19, 20, 21],
-}});
-~~~
-
-### Between
-
-The `$between` property needs an object as value with the column name as key and an  `Array` with the min and max values as value.
-
-~~~js
-User.where({ $between: {
-  age: [18, 21],
-}});
-~~~
-
-If multiple properties are present they get connected by an `and` operator.
-
-~~~js
-User.where({ $between: {
-  age: [18, 21],
-  size: [160, 185],
-}});
-~~~
-
-### NotBetween
-
-`$notBetween` works same as `$between` but inverts the result.
-
-~~~js
-User.where({ $notBetween: {
-  age: [18, 21],
-}});
-~~~
-
-~~~js
-User.where({ $notBetween: {
-  age: [18, 21],
-  size: [160, 185],
-}});
-~~~
-
-### Match
-
-The `$match` property needs an object as value with the column name as key and an `regex` with the min and max values as value.
-
-~~~js
-User.where({ $between: {
-  age: [18, 21],
-}});
-~~~
-
-If multiple properties are present they get connected by an `and` operator.
-
-~~~js
-User.where({ $between: {
-  age: [18, 21],
-  size: [160, 185],
-}});
-~~~
-
-### Filter
-
-The `$filter` property allows to write custom filter queries. Pass an function to filter the items.
-
-~~~js
-User.where({ $filter: (item) => {
-  return ...
-}});
-~~~
+```
+
+When neither `localStorage` (option) nor `globalThis.localStorage` is available, the constructor throws — letting you fail fast in environments where the Web Storage API is not present.
+
+## Wiring a Model
+
+```ts
+import { Model } from '@next-model/core';
+import { LocalStorageConnector } from '@next-model/local-storage-connector';
+
+const connector = new LocalStorageConnector();
+
+class Note extends Model({
+  tableName: 'notes',
+  connector,
+  init: (props: { title: string; body: string }) => props,
+}) {}
+
+await Note.create({ title: 'Hello', body: 'world' });
+await Note.count();           // 1
+```
+
+## Feature → connector specifics
+
+### Storage layout
+
+Each table is stored under `${prefix}${tableName}${suffix}` as a JSON-serialised array. A sidecar key `${prefix}${tableName}${suffix}__nextId` tracks the next auto-increment id so deleted rows never have their id reused.
+
+Reads load the table on first access of a request; writes serialise back after every mutation. There is no in-memory cache, so swapping `localStorage` between tabs (e.g. browser sync) is observed on the next call.
+
+### Filter operators, aggregates, ordering
+
+Inherited from `MemoryConnector`. All operators (`$and`, `$or`, `$not`, `$in`, `$notIn`, `$null`, `$notNull`, `$between`, `$notBetween`, `$gt/$gte/$lt/$lte`, `$like`, `$async`, `$raw`) and the same ordering / limit / skip semantics apply. `$like` uses the `MemoryConnector`'s pattern matcher, not SQL `LIKE`.
+
+### `execute(query, bindings)`
+
+Inherited from `MemoryConnector`: the `query` string is evaluated as a JavaScript expression over the in-memory rows. Use it only with code you control — there is no SQL parser or sanitiser between the string and the JS engine.
+
+### Transactions
+
+Inherited from `MemoryConnector`: `transaction(fn)` snapshots `storage` and `lastIds` (via `structuredClone`), runs `fn`, and either commits in place or rolls back to the snapshot on throw. The whole `localStorage` tree is *not* synchronised across tabs during the transaction, so concurrent writers from another tab can race a rollback.
+
+### `batchInsert`
+
+Each row is pushed to the in-memory table array, then the table is serialised back to `localStorage`. Auto-increment ids come from the per-table `__nextId` counter (incremented even after deletes).
+
+### Schema DSL
+
+`createTable(name, blueprint)` initialises an empty table array; `dropTable(name)` removes both the data array and the `__nextId` counter; `hasTable(name)` checks whether the data key exists. Column types declared in the blueprint are validated up-front via `defineTable` but not enforced at runtime — `localStorage` has no schema layer.
 
 ## Changelog
 
-See [history](HISTORY.md) for more details.
-
-* `0.1.0` **2017-02-25** First release compatible with NextModel 0.2.0
-* `0.2.0` **2017-02-25** Added missing dependency for CI
-* `0.3.0` **2017-02-25** Improved browser compatibility
-* `0.4.0` **2017-02-27** Stored nextId separately
-* `0.4.1` **2017-02-27** Updated next-model dependency
-* `0.4.2` **2017-02-28** Updated next-model dependency
-* `0.4.3` **2017-04-05** Updated next-model dependency
+See [`HISTORY.md`](./HISTORY.md).

--- a/packages/migrations/README.md
+++ b/packages/migrations/README.md
@@ -1,0 +1,120 @@
+# @next-model/migrations
+
+Connector-agnostic schema migration runner for [`@next-model/core`](../core).
+
+Works with any `Connector` — `MemoryConnector`, `KnexConnector` (sqlite/pg/mysql), `DataApiConnector`, `LocalStorageConnector`, or your own. Migrations declare schema changes through the core schema DSL (`connector.createTable(name, t => …)`); raw SQL is available as an escape hatch via `connector.execute(sql, bindings)`.
+
+Zero runtime dependencies beyond `@next-model/core`. Connector packages are consumed only at test time.
+
+## Installation
+
+```sh
+pnpm add @next-model/migrations @next-model/core
+```
+
+## A migration
+
+```ts
+import type { Migration } from '@next-model/migrations';
+
+export const m_2026_04_24_create_users: Migration = {
+  version: '20260424100000',
+  async up(connector) {
+    await connector.createTable('users', (t) => {
+      t.integer('id', { primary: true, autoIncrement: true });
+      t.string('name');
+      t.integer('age');
+      t.timestamps();
+    });
+    await connector.createTable('user_emails', (t) => {
+      t.integer('id', { primary: true, autoIncrement: true });
+      t.integer('user_id');
+      t.string('email', { unique: true });
+      t.index(['user_id']);
+    });
+  },
+  async down(connector) {
+    await connector.dropTable('user_emails');
+    await connector.dropTable('users');
+  },
+};
+```
+
+## Running migrations
+
+```ts
+import { Migrator } from '@next-model/migrations';
+import { KnexConnector } from '@next-model/knex-connector';
+
+import { m_2026_04_24_create_users } from './migrations/2026-04-24-create-users.js';
+import { m_2026_04_28_add_role } from './migrations/2026-04-28-add-role.js';
+
+const migrations = [m_2026_04_24_create_users, m_2026_04_28_add_role];
+
+const migrator = new Migrator({
+  connector: new KnexConnector({ client: 'pg', connection: process.env.DATABASE_URL }),
+  // tableName: 'schema_migrations',  // default — identifier-validated
+});
+
+await migrator.init();
+await migrator.migrate(migrations);
+```
+
+The `schema_migrations` tracking table is created on `init()`. Each `up`/`down` runs inside `connector.transaction` so a thrown migration body is rolled back atomically; the tracking row is only written after the body succeeds.
+
+## Public API
+
+| Method | Purpose |
+|--------|---------|
+| `init()` | Create the tracking table. Idempotent. |
+| `drop()` | Drop the tracking table (does **not** roll back applied migrations). |
+| `appliedVersions()` | `string[]` — versions already applied, in order. |
+| `appliedEntries()` | `{ version, name, appliedAt }[]` — same plus name and ISO timestamp. |
+| `pending(migrations)` | Subset of `migrations` that have not been applied yet. |
+| `status(migrations)` | `MigrationStatus[]` — one entry per provided migration with `{ version, name, isApplied, appliedAt?, parent? }`. |
+| `migrate(migrations, opts?)` | Apply pending migrations in topological order. `opts.parallel = true` runs independent dependency waves concurrently. |
+| `up(migration)` | Apply a single migration. Throws `MigrationAlreadyAppliedError` if it ran already. |
+| `down(migration)` | Revert a single migration. Throws `MigrationNotAppliedError` if it never ran. |
+| `rollback(migrations, steps?)` | Roll back the last `steps` (default 1) migrations in reverse topological order. |
+
+## Dependency graph
+
+Migrations may declare `parent?: string[]` to depend on one or more prior versions:
+
+```ts
+export const m_2026_04_28_add_role: Migration = {
+  version: '20260428080000',
+  parent: ['20260424100000'],
+  up: async (c) => { /* … */ },
+  down: async (c) => { /* … */ },
+};
+```
+
+When `parent` is omitted, the previous version in the sorted list becomes the implicit parent (matching the historical sequential behaviour). An empty `parent: []` marks a root node with no dependencies.
+
+`Migrator` topologically sorts migrations before applying:
+
+- Cycles raise `MigrationCycleError`.
+- A `parent` not present in the input list raises `MigrationParentMissingError`.
+
+`migrate(migrations, { parallel: true })` runs each topological wave via `Promise.all`, so independent branches execute concurrently. Sequential mode remains the default. `rollback` always runs in reverse topological order regardless of mode.
+
+## Versioning
+
+Versions are sorted via `localeCompare` — zero-padded numeric strings (`'20260424100000'`) and ISO-like timestamps both sort naturally.
+
+## Errors
+
+All errors inherit from `MigrationError`:
+
+| Error | Raised when |
+|-------|-------------|
+| `MigrationAlreadyAppliedError` | `up(migration)` is called for a version already in `schema_migrations`. |
+| `MigrationNotAppliedError` | `down(migration)` is called for a version not in `schema_migrations`. |
+| `MigrationMissingError` | `rollback` cannot find a migration definition matching an applied version. |
+| `MigrationParentMissingError` | A `parent` reference doesn't exist in the input migration list. |
+| `MigrationCycleError` | The dependency graph has a cycle. |
+
+## Changelog
+
+See [`HISTORY.md`](./HISTORY.md).


### PR DESCRIPTION
## Summary

Replaces the Travis-era `NextModel<Schema>()` boilerplate in every connector README with documentation that matches the current `Model({...})` factory and the actual connector behaviour.

- **Top-level `README.md`** — monorepo overview, package list, quick start, supported runtime, dev workflow.
- **`@next-model/migrations`** — brand-new README covering the `Migrator` API (`init`, `migrate`, `up`, `down`, `rollback`, `status`, `pending`, `appliedVersions`, `appliedEntries`), the optional `parent[]` dependency graph, parallel-wave execution, version sorting, and the `MigrationError` taxonomy.
- **`@next-model/knex-connector`** — feature → driver mapping for the schema DSL, every filter operator, raw `execute` per dialect, transactions (joining vs. nesting), and the per-driver `batchInsert` strategy (sqlite per-row, pg `RETURNING`, mysql consecutive-id expansion). Notes the new `test-knex-real-db` matrix.
- **`@next-model/data-api-connector`** — explains the knex-as-query-builder + injectable `DataApiClient` design, named-binding compilation, transaction semantics, the `batchInsert` re-fetch strategy, and the schema DSL bridge.
- **`@next-model/local-storage-connector`** — storage layout (`__nextId` sidecar), inheritance from `MemoryConnector`, transactional snapshot semantics, schema DSL behaviour without runtime enforcement.

Stacked on #81.

## Test plan

- [ ] Local pre-push pipeline — `pnpm lint`, `pnpm -r build`, `pnpm typecheck`, `pnpm test` all green.
- [ ] CI matrix (`test (22.x)` / `test (24.x)`) stays green — README-only PR shouldn't move any of the actual checks.
- [ ] Real-DB legs (`test-knex-real-db (pg)` / `test-knex-real-db (mysql2)`) stay green.