### PR TITLE
PR 67: Root README demos table

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,27 @@ This repository is a pnpm workspace; each published package lives under `package
 
 ## Demos
 
-End-to-end runnable scripts live under [`demos/`](./demos). Each demo is one self-contained `demo.ts` runnable via `pnpm start` (Node's experimental type-stripping does the TS work — no `tsx` / `ts-node`). The first wave covers the zero-infrastructure connectors (`memory`, `sqlite`, `local-storage`); native database demos with `docker-compose` ship in follow-ups.
+End-to-end runnable projects live under [`demos/`](./demos). Every demo is self-contained and uses Node's built-in TypeScript stripping — no `tsx` / `ts-node` / build step.
+
+| Demo | Connector / adapter | Infra |
+|---|---|---|
+| [`memory-node`](./demos/memory-node) | `@next-model/core` (`MemoryConnector`) | none |
+| [`sqlite-node`](./demos/sqlite-node) | `@next-model/sqlite-connector` | none (in-memory db) |
+| [`local-storage-node`](./demos/local-storage-node) | `@next-model/local-storage-connector` | none (in-memory `localStorage` shim) |
+| [`postgres-node`](./demos/postgres-node) | `@next-model/postgres-connector` | `docker compose up -d` (postgres:17) |
+| [`mysql-node`](./demos/mysql-node) | `@next-model/mysql-connector` | `docker compose up -d` (mysql:8) |
+| [`mariadb-node`](./demos/mariadb-node) | `@next-model/mariadb-connector` | `docker compose up -d` (mariadb:11) |
+| [`redis-node`](./demos/redis-node) | `@next-model/redis-connector` | `docker compose up -d` (redis:7) |
+| [`valkey-node`](./demos/valkey-node) | `@next-model/valkey-connector` | `docker compose up -d` (valkey:8) |
+| [`mongodb-node`](./demos/mongodb-node) | `@next-model/mongodb-connector` | `docker compose up -d` (mongo:7) |
+| [`knex-node`](./demos/knex-node) | `@next-model/knex-connector` (sqlite default, env-switchable pg/mysql) | sqlite: none; `docker compose --profile pg|mysql up -d` for the others |
+| [`aurora-data-api-node`](./demos/aurora-data-api-node) | `@next-model/aurora-data-api-connector` via `MockDataApiClient` | none |
+| [`react-todo`](./demos/react-todo) | React 19 + Vite + `@next-model/local-storage-connector` (multi-user todo via per-user prefix) | none (browser) |
+| [`nextjs-todo`](./demos/nextjs-todo) | Next.js 15 App Router + `@next-model/sqlite-connector` — server components + server actions, multi-user via cookie | none (sqlite file at `./.data/`) |
+| [`express-rest-api-node`](./demos/express-rest-api-node) | Express 5 + `@next-model/express-rest-api` + `@next-model/sqlite-connector` — drives every REST action through per-action auth + response mapping | none (in-memory sqlite) |
+| [`graphql-api-node`](./demos/graphql-api-node) | `graphql-http` + `@next-model/graphql-api` + `@next-model/sqlite-connector` — drives every GraphQL op through per-op auth + per-row serialize | none (in-memory sqlite) |
+
+The [`demos/README.md`](./demos/README.md) covers the running convention in detail (`pnpm install && pnpm start` in each demo; `pnpm db:up` / `pnpm db:down` for the service-backed ones).
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

- Expands the short paragraph under **Demos** in the root README into a package-style table listing every demo, its connector/adapter, and its infra requirement.
- Mirrors the already-existing \"Packages\" table format so readers can scan both at a glance.

## Test plan

- [x] Docs-only PR — CI skips everything except the \`changes\` job by design (paths-filter excludes \`**/*.md\`).
- [x] Links validated: each table entry points to the correct \`./demos/<name>\` directory that exists on disk.