### PR TITLE
Model.fields(...keys) chainable for partial fetches

### DIFF
--- a/packages/core/HISTORY.md
+++ b/packages/core/HISTORY.md
@@ -4,6 +4,7 @@
 
 Rolling changelog for the next major release. Items below are appended in the order they ship; this list will be finalized into a version heading when the release is cut.
 
+- New `Model.fields(...keys)` chainable for partial fetches — restricts `all()` / `first()` / `last()` / `find()` / `findBy()` to the listed columns while still returning Model instances. Primary key(s) are always included even when not in the list so instances can still `save` / `reload` / `delete`. `allFields()` undoes the restriction; `unscoped()` also clears it. Built on top of the existing `Connector.select(scope, ...keys)` primitive — no connector changes required.
 - `demos/node/` split into `server/` (DB drivers / Express / GraphQL / native modules) and `client/` (pure-JS connectors that also work in a browser: `memory`, `local-storage`). New `demos/nextjs/api` — a Next.js 15 App Router app that exposes a REST resource via `@next-model/nextjs-api` route handlers (per-action auth, sqlite-backed) alongside the existing `demos/nextjs/todo`. pnpm workspace globs updated (`demos/node/server/*`, `demos/node/client/*`). Every demo README — including `nextjs/todo` — now points at the `pnpm rebuild better-sqlite3` fix for the `NODE_MODULE_VERSION` mismatch users hit when the native binding was compiled against a different Node version than the one running `next dev`.
 
 ### Tooling

--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -138,6 +138,13 @@ export class ModelClass {
   /** Column used by `discard()` / `restore()` + the soft-delete scope. */
   static softDeleteColumn: string = 'discardedAt';
   static softDelete: 'active' | 'only' | false = false;
+  /**
+   * When set, `all()` / `first()` / `last()` / `find()` / `findBy()` fetch
+   * only these columns (plus every primary key) from the connector. Model
+   * instances are still returned; they just carry partial data. Set via the
+   * `fields(...keys)` chainable.
+   */
+  static selectedFields: string[] | undefined = undefined;
   static validators: Validator<any>[] = [];
   static callbacks: Callbacks<any> = {};
 
@@ -267,6 +274,25 @@ export class ModelClass {
       static skip = undefined;
       static order: OrderColumn<any>[] = [];
       static softDelete: 'active' | 'only' | false = false;
+      static selectedFields: string[] | undefined = undefined;
+    } as M;
+  }
+
+  /**
+   * Restrict subsequent `all()` / `first()` / `last()` / `find()` / `findBy()`
+   * fetches to the given columns. The Model's primary key(s) are always
+   * included even when omitted from the list so instances can still save,
+   * reload and delete.
+   */
+  static fields<M extends typeof ModelClass>(this: M, ...keys: string[]) {
+    return class extends (this as typeof ModelClass) {
+      static selectedFields = keys;
+    } as M;
+  }
+
+  static allFields<M extends typeof ModelClass>(this: M) {
+    return class extends (this as typeof ModelClass) {
+      static selectedFields: string[] | undefined = undefined;
     } as M;
   }
 
@@ -330,10 +356,16 @@ export class ModelClass {
   }
 
   static async all<M extends typeof ModelClass>(this: M) {
-    const items = await this.connector.query(this.modelScope());
+    const primaryKeys = Object.keys(this.keys);
+    const items = this.selectedFields
+      ? await this.connector.select(
+          this.modelScope(),
+          ...Array.from(new Set([...primaryKeys, ...this.selectedFields])),
+        )
+      : await this.connector.query(this.modelScope());
     return items.map((item) => {
       const keys: Dict<any> = {};
-      for (const key in this.keys) {
+      for (const key of primaryKeys) {
         keys[key] = item[key];
         delete item[key];
       }

--- a/packages/core/src/__tests__/fields.spec.ts
+++ b/packages/core/src/__tests__/fields.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import { MemoryConnector, Model } from '../index.js';
+
+interface Row {
+  id?: number;
+  name: string;
+  age: number;
+  active: boolean;
+  note: string;
+}
+
+function freshConnector(): MemoryConnector {
+  return new MemoryConnector({ storage: {}, lastIds: {} });
+}
+
+function buildUser(connector: MemoryConnector) {
+  return class User extends Model({
+    tableName: 'users',
+    connector,
+    timestamps: false,
+    init: (props: Row) => props,
+  }) {};
+}
+
+async function seed(User: ReturnType<typeof buildUser>) {
+  await User.createMany([
+    { name: 'Ada', age: 36, active: true, note: 'secret a' },
+    { name: 'Linus', age: 12, active: true, note: 'secret b' },
+    { name: 'Old', age: 99, active: false, note: 'secret c' },
+  ]);
+}
+
+describe('Model.fields chainable', () => {
+  it('restricts all() to the listed columns (plus the primary key)', async () => {
+    const connector = freshConnector();
+    const User = buildUser(connector);
+    await seed(User);
+    const rows = await User.fields('name').all();
+    for (const row of rows) {
+      const attrs = row.attributes() as Record<string, unknown>;
+      expect(attrs.id).toBeDefined(); // primary key always included
+      expect(attrs.name).toBeDefined();
+      expect(attrs.age).toBeUndefined();
+      expect(attrs.note).toBeUndefined();
+    }
+    expect(rows.map((r) => (r.attributes() as Row).name)).toEqual(['Ada', 'Linus', 'Old']);
+  });
+
+  it('composes with filterBy + orderBy', async () => {
+    const connector = freshConnector();
+    const User = buildUser(connector);
+    await seed(User);
+    const rows = await User.filterBy({ active: true })
+      .orderBy({ key: 'age', dir: -1 })
+      .fields('name', 'age')
+      .all();
+    expect(rows.map((r) => (r.attributes() as Row).name)).toEqual(['Ada', 'Linus']);
+    const sample = rows[0].attributes() as Record<string, unknown>;
+    expect(sample.note).toBeUndefined();
+  });
+
+  it('first() and last() respect the chain', async () => {
+    const connector = freshConnector();
+    const User = buildUser(connector);
+    await seed(User);
+    const first = await User.fields('name').first();
+    expect(first).toBeDefined();
+    const firstAttrs = first!.attributes() as Record<string, unknown>;
+    expect(firstAttrs.name).toBe('Ada');
+    expect(firstAttrs.note).toBeUndefined();
+
+    const last = await User.fields('name').last();
+    expect((last!.attributes() as Row).name).toBe('Old');
+  });
+
+  it('find() honours the chain', async () => {
+    const connector = freshConnector();
+    const User = buildUser(connector);
+    await seed(User);
+    const row = await User.fields('name').find(2);
+    const attrs = row.attributes() as Record<string, unknown>;
+    expect(attrs.id).toBe(2);
+    expect(attrs.name).toBe('Linus');
+    expect(attrs.note).toBeUndefined();
+  });
+
+  it('primary key is included even when not listed', async () => {
+    const connector = freshConnector();
+    const User = buildUser(connector);
+    await seed(User);
+    const rows = await User.fields('name').all();
+    for (const row of rows) {
+      expect((row.attributes() as Row).id).toBeDefined();
+    }
+  });
+
+  it('allFields() resets back to the full fetch', async () => {
+    const connector = freshConnector();
+    const User = buildUser(connector);
+    await seed(User);
+    const partial = User.fields('name');
+    const full = partial.allFields();
+    const row = (await full.first())!.attributes() as Row;
+    expect(row.age).toBe(36);
+    expect(row.note).toBe('secret a');
+  });
+
+  it('unscoped() also clears the field selection', async () => {
+    const connector = freshConnector();
+    const User = buildUser(connector);
+    await seed(User);
+    const partial = User.fields('name');
+    const reset = partial.unscoped();
+    const row = (await reset.first())!.attributes() as Row;
+    expect(row.age).toBe(36);
+    expect(row.note).toBe('secret a');
+  });
+});


### PR DESCRIPTION
## Summary

- New \`Model.fields(...keys)\` chainable: restricts subsequent \`all()\` / \`first()\` / \`last()\` / \`find()\` / \`findBy()\` to the listed columns while still returning Model instances. The primary key(s) are always included in the fetched column set so instances can still \`save\` / \`reload\` / \`delete\`.
- Implementation: sets \`static selectedFields\` on the subclassed chain and routes \`all()\` through the connector's existing \`select(scope, ...keys)\` primitive instead of \`query(scope)\`. **No connector changes required.**
- \`Model.allFields()\` resets to the full fetch; \`unscoped()\` also clears the selection.

## Test plan

- [x] \`pnpm --filter @next-model/core test\` — 5308 tests green (7 new)
  - Covers: \`all()\` restriction, composition with \`filterBy\` / \`orderBy\`, \`first()\` / \`last()\` / \`find()\` honouring the chain, primary key always included, \`allFields()\` + \`unscoped()\` reset
- [x] \`pnpm lint\` / \`pnpm typecheck\` — clean across the workspace

Chained on top of PR 117.