### PR TITLE
ci: add @next-model/react to coverage matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       zod: ${{ steps.filter.outputs.zod }}
       typebox: ${{ steps.filter.outputs.typebox }}
       arktype: ${{ steps.filter.outputs.arktype }}
+      react: ${{ steps.filter.outputs.react }}
       ci: ${{ steps.filter.outputs.ci }}
       code: ${{ steps.filter.outputs.code }}
     steps:
@@ -114,6 +115,9 @@ jobs:
             arktype:
               - 'packages/arktype/**'
               - '!packages/arktype/**/*.md'
+            react:
+              - 'packages/react/**'
+              - '!packages/react/**/*.md'
             ci:
               - '.github/**'
             code:
@@ -366,6 +370,26 @@ jobs:
         with:
           name: coverage-arktype
           path: packages/arktype/coverage/coverage-summary.json
+          if-no-files-found: ignore
+
+  test-react:
+    needs: changes
+    if: needs.changes.outputs.core == 'true' || needs.changes.outputs.react == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @next-model/core --filter @next-model/react -r build
+      - run: pnpm --filter @next-model/react coverage
+      - uses: actions/upload-artifact@v7
+        with:
+          name: coverage-react
+          path: packages/react/coverage/coverage-summary.json
           if-no-files-found: ignore
 
   test-migrations-generator:
@@ -709,6 +733,7 @@ jobs:
       - test-zod
       - test-typebox
       - test-arktype
+      - test-react
       - test-migrations
       - test-postgres-connector
       - test-mysql-connector


### PR DESCRIPTION
## Summary

The react package shipped without a corresponding \`test-react\` job, so its coverage column didn't appear in the PR coverage comment. This adds:

- \`react\` filter to the \`changes\` job's paths-filter (gates test runs to react-touching PRs).
- New \`test-react\` job — builds \`@next-model/core\` + \`@next-model/react\` and runs \`pnpm --filter @next-model/react coverage\`, uploading the summary as \`coverage-react\`.
- Adds \`test-react\` to \`coverage-report\`'s \`needs\`.

Same pattern as every other per-package coverage job. The coverage-comment script auto-discovers artifacts so no script changes are needed.

## Test plan

- [ ] Local run \`pnpm --filter @next-model/react coverage\` produces summary (verified: 92.59% stmts, 88.99% functions, 93.69% lines).
- [ ] On this PR's CI run, the coverage table comment includes a \`react\` row.