### PR TITLE
chore: build packages before pack via prepack hook

### DIFF
--- a/packages/arktype/package.json
+++ b/packages/arktype/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "peerDependencies": {
     "@next-model/core": "workspace:*",

--- a/packages/aurora-data-api-connector/package.json
+++ b/packages/aurora-data-api-connector/package.json
@@ -36,7 +36,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "dependencies": {
     "data-api-client": "^2.1.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/packages/express-rest-api/package.json
+++ b/packages/express-rest-api/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "peerDependencies": {
     "@next-model/core": "workspace:*",

--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "peerDependencies": {
     "@graphql-tools/schema": "^10.0.0",

--- a/packages/knex-connector/package.json
+++ b/packages/knex-connector/package.json
@@ -32,7 +32,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "dependencies": {
     "knex": "^3.2.9"

--- a/packages/local-storage-connector/package.json
+++ b/packages/local-storage-connector/package.json
@@ -32,7 +32,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "dependencies": {
     "@next-model/core": "workspace:*"

--- a/packages/mariadb-connector/package.json
+++ b/packages/mariadb-connector/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "dependencies": {
     "@next-model/mysql-connector": "workspace:*",

--- a/packages/migrations-generator/package.json
+++ b/packages/migrations-generator/package.json
@@ -36,7 +36,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc && chmod +x dist/cli.js",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "dependencies": {
     "@next-model/core": "workspace:*"

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -32,7 +32,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "dependencies": {
     "@next-model/core": "workspace:*"

--- a/packages/mongodb-connector/package.json
+++ b/packages/mongodb-connector/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "dependencies": {
     "mongodb": "^7.2.0"

--- a/packages/mysql-connector/package.json
+++ b/packages/mysql-connector/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "dependencies": {
     "mysql2": "^3.22.3"

--- a/packages/nextjs-api/package.json
+++ b/packages/nextjs-api/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "peerDependencies": {
     "@next-model/core": "workspace:*"

--- a/packages/postgres-connector/package.json
+++ b/packages/postgres-connector/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "dependencies": {
     "pg": "^8.20.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,7 +32,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0"

--- a/packages/redis-connector/package.json
+++ b/packages/redis-connector/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "dependencies": {
     "redis": "^4.7.1"

--- a/packages/sqlite-connector/package.json
+++ b/packages/sqlite-connector/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "dependencies": {
     "better-sqlite3": "^12.9.0"

--- a/packages/typebox/package.json
+++ b/packages/typebox/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "peerDependencies": {
     "@next-model/core": "workspace:*",

--- a/packages/valkey-connector/package.json
+++ b/packages/valkey-connector/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "dependencies": {
     "@next-model/redis-connector": "workspace:*",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w",
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
-    "prepublishOnly": "pnpm build"
+    "prepack": "pnpm build"
   },
   "peerDependencies": {
     "@next-model/core": "workspace:*",


### PR DESCRIPTION
## Summary
- Replace `prepublishOnly` with the standard `prepack` lifecycle hook in all 20 public packages
- `pnpm pack` and `npm pack` now automatically build first, eliminating the risk of packing stale code
- The release workflow (which iterates `pnpm pack` per package) inherits the behavior with no workflow changes

## Test plan
- [ ] CI passes (lint, typecheck, tests, release-helper tests)
- [ ] Manual: in a package, delete `dist/` and run `pnpm pack` — verify a fresh build runs before the tarball is produced
- [ ] Dry-run release workflow on a fork or verify the next release tarballs include current code