### PR TITLE
ci(release): use corepack to install latest npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,14 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Use latest npm (for Trusted Publishing support)
-        run: npm install -g npm@latest
+        # Workaround: Node 22.22.2's bundled npm 10.9.7 has a broken dep tree
+        # (missing promise-retry), so `npm install -g npm@latest` fails. Corepack
+        # fetches the npm binary directly and skips the broken arborist rebuild.
+        # See actions/runner-images#13883, npm/cli#9151.
+        run: |
+          corepack enable
+          corepack prepare npm@latest --activate
+          npm --version
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- Node 22.22.2 in the GitHub Actions runner toolcache ships a broken bundled npm 10.9.7 — its `@npmcli/arborist` dep is missing `promise-retry`, so `npm install -g npm@latest` aborts during the bundled npm's own rebuild phase before the new npm can take over.
- Switch the "Use latest npm" step to corepack, which downloads npm directly from the registry and bypasses the broken arborist path. Trusted Publishing (OIDC, no `NPM_TOKEN`) still works since the activated `npm` is current.

Refs [actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883), [npm/cli#9151](https://github.com/npm/cli/issues/9151).

## Test plan
- [ ] Dispatch the Release workflow on `vNext` (after merge) with a prerelease version and confirm the "Use latest npm" step prints a current npm version (≥ 11.5.x) instead of failing on the missing `promise-retry` module.
- [ ] Confirm the rest of the workflow (sanity build, version bump, tag, pack, publish) runs to completion.