### PR TITLE
ci(release): drop registry-url so OIDC trusted publishing actually runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,12 @@ jobs:
         with:
           node-version: 22.x
           cache: pnpm
-          registry-url: https://registry.npmjs.org
+          # Intentionally omit registry-url: it makes setup-node write an .npmrc with
+          # _authToken=${NODE_AUTH_TOKEN} AND export a placeholder NODE_AUTH_TOKEN of
+          # XXXXX-XXXXX-XXXXX-XXXXX when no token is provided. npm publish then sends
+          # the bogus placeholder, the registry returns 404, and OIDC trusted
+          # publishing is never attempted. Without registry-url npm defaults to
+          # registry.npmjs.org and uses GitHub OIDC env vars automatically.
 
       - name: Use latest npm (for Trusted Publishing support)
         # Workaround: Node 22.22.2's bundled npm 10.9.7 has a broken dep tree


### PR DESCRIPTION
## Summary
Follow-up to #167. The release workflow now upgrades npm correctly via corepack, but the publish step still 404'd against the npm registry even though `@next-model/arktype` exists and the Trusted Publisher is configured on npmjs.com.

## Root cause
`actions/setup-node` with `registry-url:` set:
1. Writes an `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`.
2. Exports a placeholder `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX` when no real token is provided ([source](https://github.com/actions/setup-node/blob/main/src/authutil.ts)).

`npm publish` then sends the literal placeholder as a bearer token. The registry rejects it, returns the misleading `404 Not Found '@next-model/arktype@1.0.0-rc.1' is not in this registry`, and the OIDC trusted publishing flow is never attempted.

## Fix
Drop `registry-url:` from `actions/setup-node`. Without it, no `.npmrc` is written, no placeholder token is exported, and `npm publish` defaults to `registry.npmjs.org` while reading the GitHub Actions OIDC env vars (`ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN`) for trusted publishing.

## Test plan
- [ ] After merge, dispatch the Release workflow at a fresh prerelease version (e.g. `1.0.0-rc.2` — `rc.1` already has a tag from the failed attempt) and confirm the publish step succeeds for every public package.
- [ ] Confirm each tarball is uploaded with provenance (visible on the package page on npmjs.com).