### PR TITLE
ci(release): bump to Node 24 LTS so bundled npm supports trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,24 +88,19 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          # Node 24 (current LTS) ships npm 11.x, which supports OIDC trusted
+          # publishing. Node 22 ships npm 10.9.7, which does not - and the
+          # in-place self-upgrade path is broken in the runner toolcache
+          # (actions/runner-images#13883, npm/cli#9151).
+          node-version: 24.x
           cache: pnpm
-          # Intentionally omit registry-url: it makes setup-node write an .npmrc with
-          # _authToken=${NODE_AUTH_TOKEN} AND export a placeholder NODE_AUTH_TOKEN of
-          # XXXXX-XXXXX-XXXXX-XXXXX when no token is provided. npm publish then sends
-          # the bogus placeholder, the registry returns 404, and OIDC trusted
-          # publishing is never attempted. Without registry-url npm defaults to
-          # registry.npmjs.org and uses GitHub OIDC env vars automatically.
-
-      - name: Use latest npm (for Trusted Publishing support)
-        # Workaround: Node 22.22.2's bundled npm 10.9.7 has a broken dep tree
-        # (missing promise-retry), so `npm install -g npm@latest` fails. Corepack
-        # fetches the npm binary directly and skips the broken arborist rebuild.
-        # See actions/runner-images#13883, npm/cli#9151.
-        run: |
-          corepack enable
-          corepack prepare npm@latest --activate
-          npm --version
+          # Intentionally omit registry-url: it makes setup-node write an .npmrc
+          # with _authToken=${NODE_AUTH_TOKEN} AND export a placeholder
+          # NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX when no real token is set.
+          # npm publish would then send the placeholder, the registry would
+          # reject it, and OIDC trusted publishing would never be attempted.
+          # Without registry-url npm defaults to registry.npmjs.org and uses
+          # the GitHub Actions OIDC env vars automatically.
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
Follow-up to #167 and #168. The most recent release run still failed at publish with `ENEEDAUTH`. Inspecting the `Use latest npm` step log:

```
corepack prepare npm@latest --activate
Preparing npm@latest for immediate activation...
10.9.7
```

`npm --version` still printed **10.9.7**. `corepack prepare … --activate` only registers a version internally; `corepack enable` doesn't create an `npm` shim by default (only `pnpm` and `yarn`). So every release run since the corepack PR has been publishing with the broken bundled npm 10.9.7, which doesn't support OIDC trusted publishing - hence `ENEEDAUTH` once the placeholder token from `registry-url` was removed.

## Fix
Bump `node-version` to `24.x` (current LTS since October 2025). Node 24 ships npm 11.x natively, which supports OIDC trusted publishing, so:
- The "Use latest npm" workaround step is removed entirely.
- The Node 22 toolcache `promise-retry` regression no longer applies.
- Trusted publishing should actually run on the next dispatch.

## Test plan
- [ ] After merge, dispatch the Release workflow at `1.0.0-rc.3` (rc.1 + rc.2 already have tags from prior failed attempts).
- [ ] Confirm the publish step succeeds for every public package and provenance attestations show up on each package page on npmjs.com.