### PR TITLE
chore: align package repository URLs with the monorepo

### DIFF
--- a/packages/aurora-data-api-connector/package.json
+++ b/packages/aurora-data-api-connector/package.json
@@ -23,7 +23,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/tamino-martinius/node-next-model-aurora-data-api-connector.git"
+    "url": "https://github.com/tamino-martinius/node-next-model.git",
+    "directory": "packages/aurora-data-api-connector"
   },
   "engines": {
     "node": ">=22"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/tamino-martinius/node-data-api-model.git"
+    "url": "https://github.com/tamino-martinius/node-next-model.git",
+    "directory": "packages/core"
   },
   "engines": {
     "node": ">=22"

--- a/packages/knex-connector/package.json
+++ b/packages/knex-connector/package.json
@@ -19,7 +19,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/tamino-martinius/node-next-model-knex-connector.git"
+    "url": "https://github.com/tamino-martinius/node-next-model.git",
+    "directory": "packages/knex-connector"
   },
   "engines": {
     "node": ">=22"

--- a/packages/local-storage-connector/package.json
+++ b/packages/local-storage-connector/package.json
@@ -19,7 +19,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/tamino-martinius/node-next-model-local-storage-connector.git"
+    "url": "https://github.com/tamino-martinius/node-next-model.git",
+    "directory": "packages/local-storage-connector"
   },
   "engines": {
     "node": ">=22"

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -19,7 +19,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/tamino-martinius/node-next-model.git"
+    "url": "https://github.com/tamino-martinius/node-next-model.git",
+    "directory": "packages/migrations"
   },
   "engines": {
     "node": ">=22"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,7 +19,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/tamino-martinius/node-next-model.git"
+    "url": "https://github.com/tamino-martinius/node-next-model.git",
+    "directory": "packages/react"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Summary
After #169 fixed trusted publishing, the release workflow successfully published `@next-model/arktype@1.0.0-rc.3` (provenance and all). The next package failed with:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@next-model%2faurora-data-api-connector
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is
"git+https://github.com/tamino-martinius/node-next-model-aurora-data-api-connector.git",
expected to match "https://github.com/tamino-martinius/node-next-model" from provenance
```

npm cross-checks `package.json#repository.url` against the GitHub repo identified in the sigstore provenance bundle (this monorepo) and rejects mismatches.

Four packages still pointed at their pre-monorepo standalone repos:
- `@next-model/aurora-data-api-connector` → `node-next-model-aurora-data-api-connector.git`
- `@next-model/core` → `node-data-api-model.git`
- `@next-model/knex-connector` → `node-next-model-knex-connector.git`
- `@next-model/local-storage-connector` → `node-next-model-local-storage-connector.git`

Two more (`migrations`, `react`) had the right URL but were missing the `directory` subpath the rest of the monorepo carries.

## Fix
Repoint all six to `https://github.com/tamino-martinius/node-next-model.git` and add the `packages/<name>` `directory` subpath so every package matches the convention already used by `arktype`, `zod`, etc.

## Test plan
- [ ] After merge, dispatch the Release workflow at `1.0.0-rc.4` (rc.1/rc.2/rc.3 already have tags from the prior failed attempts; arktype is already published at rc.3 so only rc.4+ will be a clean run for it).
- [ ] Confirm publish succeeds for every public package and provenance attestations show on each package page on npmjs.com.