### PR TITLE
docs: migrate root README + 17 skills to schema-first API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,25 @@ A typed, promise-based ORM for TypeScript. Define models with a factory, chain i
 ### Define a model
 
 ```ts
-import { Model } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
 import { SqliteConnector } from '@next-model/sqlite-connector';
 
-const connector = new SqliteConnector(':memory:');
+const schema = defineSchema({
+  users: {
+    columns: {
+      id:        { type: 'integer', primary: true, autoIncrement: true },
+      firstName: { type: 'string' },
+      lastName:  { type: 'string' },
+      age:       { type: 'integer' },
+    },
+  },
+});
+
+const connector = new SqliteConnector(':memory:', { schema });
 
 class User extends Model({
-  tableName: 'users',
   connector,
-  init: (props: { firstName: string; lastName: string; age: number }) => props,
+  tableName: 'users',
 }) {
   get name() {
     return `${this.firstName} ${this.lastName}`;
@@ -97,7 +107,7 @@ This repository is a pnpm workspace; each published package lives under `package
 | [`@next-model/graphql-api`](./packages/graphql-api) | GraphQL schema generator — six default CRUD operations with per-operation auth + per-row response mapping. |
 | [`@next-model/nextjs-api`](./packages/nextjs-api) | Next.js App Router adapter — `{ GET, POST, PATCH, DELETE }` route-handler exports with the same auth + mapping hook surface. |
 | [`@next-model/migrations-generator`](./packages/migrations-generator) | CLI (`nm-generate-migration`) + library for scaffolding timestamped migration files. |
-| [`@next-model/zod`](./packages/zod) | Bridge zod schemas into a Model's `init`, `validators`, and `createTable` columns — one schema, three consumers. |
+| [`@next-model/zod`](./packages/zod) | Bridge zod schemas into `toTypedColumns()` (for `defineSchema`), `init` coercion, and `validators` — one schema, three consumers. |
 | [`@next-model/typebox`](./packages/typebox) | TypeBox variant of `@next-model/zod`. |
 | [`@next-model/arktype`](./packages/arktype) | arktype variant of `@next-model/zod`. |
 

--- a/skills/next-model-arktype/SKILL.md
+++ b/skills/next-model-arktype/SKILL.md
@@ -35,35 +35,52 @@ pnpm add @next-model/arktype arktype
 ## Quick start
 
 ```ts
-import { Model, SqliteConnector } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
+import { SqliteConnector } from '@next-model/sqlite-connector';
 import { fromArkType } from '@next-model/arktype';
 import { type } from 'arktype';
 
 const UserType = type({
-  name: 'string>=2',
-  age: 'number.integer>=0',
-  active: 'boolean',
+  name:       'string>=2',
+  age:        'number.integer>=0',
+  active:     'boolean',
   'nickname?': 'string',
-  metadata: { source: 'string' },
+  metadata:   { source: 'string' },
 });
 
-const user = fromArkType(UserType);
-const connector = new SqliteConnector(':memory:');
+const bridge = fromArkType(UserType);
+
+const schema = defineSchema({
+  users: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      ...bridge.toTypedColumns(),   // name, age, active, nickname, metadata columns
+    },
+  },
+});
+
+const connector = new SqliteConnector(':memory:', { schema });
 
 class User extends Model({
-  tableName: 'users',
   connector,
-  init: user.init,
-  validators: user.validators,
+  tableName: 'users',
+  init:       bridge.init,
+  validators: bridge.validators,
 }) {}
-
-await connector.createTable('users', (t) => {
-  t.integer('id', { primary: true, autoIncrement: true, null: false });
-  user.applyColumns(t);
-});
 ```
 
-`init` invokes the callable `type(value)` — on failure it throws `ValidationError` with `ArkErrors.summary`, the same human-readable multiline string arktype prints when you call `.throw()`.
+`fromArkType(schema)` returns `{ init, validators, applyColumns, toTypedColumns }`. Use `toTypedColumns()` to plug into `defineSchema`, and wire `init` + `validators` into `Model({...})`. `init` invokes the callable `type(value)` — on failure it throws `ValidationError` with `ArkErrors.summary`, the same human-readable multiline string arktype prints when you call `.throw()`.
+
+### Using `applyColumns` for migrations
+
+`applyColumns(t)` is still useful inside `connector.createTable(...)` migration callbacks — the `defineTable` builder is imperative and operates independently from `defineSchema`:
+
+```ts
+await connector.createTable('users', (t) => {
+  t.integer('id', { primary: true, autoIncrement: true, null: false });
+  bridge.applyColumns(t);
+});
+```
 
 ## Type mapping
 

--- a/skills/next-model-aurora-data-api-connector/SKILL.md
+++ b/skills/next-model-aurora-data-api-connector/SKILL.md
@@ -71,23 +71,32 @@ Set `dialect: 'postgres'` (default) or `dialect: 'mysql'` on the constructor opt
 ## Quick start
 
 ```ts
-import { Model } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
 import { DataApiConnector } from '@next-model/aurora-data-api-connector';
+
+const schema = defineSchema({
+  users: {
+    columns: {
+      id:   { type: 'integer', primary: true, autoIncrement: true },
+      name: { type: 'string' },
+      age:  { type: 'integer' },
+    },
+  },
+});
 
 const connector = new DataApiConnector({
   secretArn: process.env.AURORA_SECRET_ARN,
   resourceArn: process.env.AURORA_CLUSTER_ARN,
   database: 'app_production',
-});
+}, { schema });
 
 class User extends Model({
-  tableName: 'users',
   connector,
-  init: (props: { name: string; age: number }) => props,
+  tableName: 'users',
 }) {}
 
 const ada = await User.create({ name: 'Ada', age: 36 });
-const adults = await User.where({ age: { $gte: 18 } }).all();
+const adults = await User.filterBy({ $gte: { age: 18 } }).all();
 ```
 
 ## Mock client
@@ -104,7 +113,7 @@ const connector = new DataApiConnector({ client });
 // stub a result for the next query
 client.enqueue({ records: [{ id: 1, name: 'Ada' }] });
 
-class User extends Model({ tableName: 'users', connector, init: (p: { name: string }) => p }) {}
+class User extends Model({ connector, tableName: 'users' }) {}
 const [ada] = await User.all();
 
 // inspect the SQL the connector produced

--- a/skills/next-model-core/SKILL.md
+++ b/skills/next-model-core/SKILL.md
@@ -37,76 +37,50 @@ pnpm add @next-model/core
 
 ## Defining a model
 
-Three idioms ship in the README.
-
-### `init`-based (legacy)
+The only supported way to construct a Model is schema-first: define a `defineSchema(...)` block, pass it to the connector, then reference the connector from `Model({...})`.
 
 ```ts
-import { Model, KeyType, SortDirection } from '@next-model/core';
-
-class User extends Model({
-  tableName: 'users',
-  init: (props: { firstName: string; lastName: string; gender?: string }) => props,
-}) {
-  get name() {
-    return `${this.firstName} ${this.lastName}`;
-  }
-}
-
-const user = await User.create({ firstName: 'John', lastName: 'Doe' });
-user.id;     // auto-assigned number
-user.name;   // 'John Doe'
-```
-
-### `defineSchema(...)` + connector
-
-```ts
-import { Model, defineSchema } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
 import { SqliteConnector } from '@next-model/sqlite-connector';
 
 const dbSchema = defineSchema({
   users: {
     columns: {
-      id: { type: 'integer', primary: true, autoIncrement: true },
-      email: { type: 'string' },
-      name: { type: 'string' },
-      age: { type: 'integer' },
+      id:         { type: 'integer', primary: true, autoIncrement: true },
+      email:      { type: 'string' },
+      name:       { type: 'string' },
+      age:        { type: 'integer' },
       archivedAt: { type: 'timestamp', null: true },
     },
   },
   posts: {
     columns: {
-      id: { type: 'integer', primary: true, autoIncrement: true },
+      id:     { type: 'integer', primary: true, autoIncrement: true },
       userId: { type: 'integer' },
-      title: { type: 'string' },
+      title:  { type: 'string' },
     },
   },
 });
 
 const connector = new SqliteConnector(':memory:', { schema: dbSchema });
 
-class User extends Model({ connector, tableName: 'users' }) {}
-class Post extends Model({ connector, tableName: 'posts' }) {}
-```
-
-Column-kind → prop-type mapping: `string`/`text` → `string`; `integer`/`bigint`/`float`/`decimal` → `number`; `boolean` → `boolean`; `date`/`datetime`/`timestamp` → `Date`; `json` → `unknown`. `null: true` widens to `T | null`. Primary columns drive `keys` (string/text → `KeyType.uuid`, numeric → `KeyType.number`).
-
-### `Model<Interface>({...})` (interface-generic props)
-
-```ts
-import { Model } from '@next-model/core';
-
-interface UserProps {
-  email: string;
-  name: string;
-  archivedAt: Date | null;
+class User extends Model({ connector, tableName: 'users' }) {
+  get displayName() { return this.name; }
 }
+class Post extends Model({ connector, tableName: 'posts' }) {}
 
-class User extends Model<UserProps>({
-  tableName: 'users',
-  // No init needed — defaults to identity. Props are typed via the generic.
-}) {}
+const user = await User.create({ email: 'john@example.com', name: 'John Doe', age: 30 });
+user.id;           // auto-assigned number
+user.displayName;  // 'John Doe'
 ```
+
+Column-kind → prop-type mapping: `string`/`text` → `string`; `integer`/`bigint`/`float`/`decimal` → `number`; `boolean` → `boolean`; `date`/`datetime`/`timestamp` → `Date`; `json` → `unknown`. `null: true` widens to `T | null`. Primary columns drive key type inference (string/text → UUID key, numeric → number key).
+
+Key rules:
+- `Model({ tableName, init, keys })` — removed. Use `defineSchema` + connector.
+- `Model<Interface>({...})` interface-generic — removed. Column types come from the schema.
+- `init` is optional. Schema-derived defaults apply column `default:` values at build time. Pass `init: (p) => ({...p, transform})` only when you need an explicit transformation.
+- `keys` is no longer a top-level option — derived from the schema's `primary: true` columns.
 
 ## Querying
 
@@ -217,8 +191,9 @@ import {
   validateConfirmation,
 } from '@next-model/core';
 
-const User = Model({
-  // ...
+class User extends Model({
+  connector,   // connector built from a schema with email, name, role, etc. columns
+  tableName: 'users',
   validators: [
     validatePresence(['email', 'name']),
     validateFormat('email', { with: /^[^@\s]+@[^@\s]+\.[^@\s]+$/ }),
@@ -229,7 +204,7 @@ const User = Model({
     validateUniqueness('email', { caseSensitive: false }),
     validateConfirmation('password'),
   ],
-});
+}) {}
 ```
 
 Every factory accepts `{ message?, allowNull?, allowBlank?, if?, unless? }`. Each instance carries an `errors` collection populated by `isValid()`.
@@ -237,7 +212,9 @@ Every factory accepts `{ message?, allowNull?, allowBlank?, if?, unless? }`. Eac
 ## Lifecycle callbacks
 
 ```ts
-Model({
+class User extends Model({
+  connector,
+  tableName: 'users',
   callbacks: {
     beforeSave:   [ (record) => { /* ... */ } ],
     beforeCreate: [ /* ... */ ],
@@ -248,7 +225,7 @@ Model({
     beforeDelete: [ /* ... */ ],
     afterDelete:  [ /* ... */ ],
   },
-});
+}) {}
 
 const unsubscribe = User.on('afterSave', (user) => {
   logger.info('user saved', user.savedChanges());
@@ -263,10 +240,21 @@ Enabled by default. `createdAt` is set on insert, `updatedAt` on every save. `to
 
 ## Soft delete
 
+`softDelete: true` requires a `discardedAt` column of type `timestamp` with `null: true` in the schema:
+
 ```ts
+// In your defineSchema block:
+//   posts: {
+//     columns: {
+//       id:          { type: 'integer', primary: true, autoIncrement: true },
+//       title:       { type: 'string' },
+//       discardedAt: { type: 'timestamp', null: true },
+//     },
+//   },
+
 class Post extends Model({
+  connector,   // connector built from a schema that includes the discardedAt column
   tableName: 'posts',
-  init: (props: { title: string; discardedAt?: Date | null }) => ({ discardedAt: null, ...props }),
   softDelete: true,
 }) {}
 
@@ -283,17 +271,51 @@ await post.restore();
 
 ## Associations
 
+Associations are declared at the schema level (not on the Model factory). The `hasMany` / `belongsTo` / `hasOne` / `hasManyThrough` target is the **table name** (string), not a class reference or thunk — so association declarations are cycle-free:
+
 ```ts
-class User extends Model({
-  tableName: 'users',
-  init: (props: { name: string }) => props,
-  associations: {
-    posts:   { hasMany:   () => Post,    foreignKey: 'userId' },
-    profile: { hasOne:    () => Profile, foreignKey: 'userId' },
-    company: { belongsTo: () => Company, foreignKey: 'companyId' },
-    roles:   { hasManyThrough: () => Role, through: () => UserRole },
+const schema = defineSchema({
+  users: {
+    columns: {
+      id:        { type: 'integer', primary: true, autoIncrement: true },
+      name:      { type: 'string' },
+      companyId: { type: 'integer' },
+    },
+    associations: {
+      posts:   { hasMany:   'posts',     foreignKey: 'userId' },
+      profile: { hasOne:    'profiles',  foreignKey: 'userId' },
+      company: { belongsTo: 'companies', foreignKey: 'companyId' },
+      roles:   { hasManyThrough: 'roles', through: 'user_roles' },
+    },
   },
-}) {}
+  posts: {
+    columns: {
+      id:     { type: 'integer', primary: true, autoIncrement: true },
+      userId: { type: 'integer' },
+      title:  { type: 'string' },
+    },
+    associations: {
+      user: { belongsTo: 'users', foreignKey: 'userId' },
+    },
+  },
+  // ... profiles, companies, roles, user_roles similarly
+});
+
+const connector = new SqliteConnector(':memory:', { schema });
+
+class User extends Model({ connector, tableName: 'users' }) {}
+class Post extends Model({ connector, tableName: 'posts' }) {}
+```
+
+To have `user.posts` return `Post[]` instead of the raw schema row shape, augment the global `ModelRegistry`:
+
+```ts
+declare module '@next-model/core' {
+  interface ModelRegistry {
+    users: import('./user').User;
+    posts: import('./post').Post;
+  }
+}
 ```
 
 Instance accessors return chainable builders, not eager promises:

--- a/skills/next-model-express-rest-api/SKILL.md
+++ b/skills/next-model-express-rest-api/SKILL.md
@@ -35,15 +35,26 @@ Minimal example mounting the adapter on an Express app for a Model:
 
 ```ts
 import express from 'express';
-import { Model, SqliteConnector } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
+import { SqliteConnector } from '@next-model/sqlite-connector';
 import { createRestRouter } from '@next-model/express-rest-api';
 
-const connector = new SqliteConnector(':memory:');
+const schema = defineSchema({
+  users: {
+    columns: {
+      id:     { type: 'integer', primary: true, autoIncrement: true },
+      name:   { type: 'string' },
+      age:    { type: 'integer' },
+      active: { type: 'boolean' },
+    },
+  },
+});
+
+const connector = new SqliteConnector(':memory:', { schema });
 
 class User extends Model({
-  tableName: 'users',
   connector,
-  init: (props: { name: string; age: number; active: boolean }) => props,
+  tableName: 'users',
 }) {}
 
 const app = express();

--- a/skills/next-model-graphql-api/SKILL.md
+++ b/skills/next-model-graphql-api/SKILL.md
@@ -36,15 +36,26 @@ Peer deps: `graphql ^16.9.0`, `@graphql-tools/schema ^10.0.0`, `@next-model/core
 
 ```ts
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { Model, SqliteConnector } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
+import { SqliteConnector } from '@next-model/sqlite-connector';
 import { buildModelResource, composeSchema } from '@next-model/graphql-api';
 
-const connector = new SqliteConnector(':memory:');
+const dbSchema = defineSchema({
+  users: {
+    columns: {
+      id:     { type: 'integer', primary: true, autoIncrement: true },
+      name:   { type: 'string' },
+      age:    { type: 'integer' },
+      active: { type: 'boolean' },
+    },
+  },
+});
+
+const connector = new SqliteConnector(':memory:', { schema: dbSchema });
 
 class User extends Model({
-  tableName: 'users',
   connector,
-  init: (props: { name: string; age: number; active: boolean }) => props,
+  tableName: 'users',
 }) {}
 
 const userResource = buildModelResource({

--- a/skills/next-model-knex-connector/SKILL.md
+++ b/skills/next-model-knex-connector/SKILL.md
@@ -83,18 +83,27 @@ Existing call sites without `{ schema }` keep working unchanged.
 ## Quick start
 
 ```ts
-import { Model } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
 import { KnexConnector } from '@next-model/knex-connector';
+
+const schema = defineSchema({
+  users: {
+    columns: {
+      id:   { type: 'integer', primary: true, autoIncrement: true },
+      name: { type: 'string' },
+      age:  { type: 'integer' },
+    },
+  },
+});
 
 const connector = new KnexConnector({
   client: 'pg',
   connection: process.env.DATABASE_URL,
-});
+}, { schema });
 
 class User extends Model({
-  tableName: 'users',
   connector,
-  init: (props: { name: string; age: number }) => props,
+  tableName: 'users',
 }) {}
 ```
 

--- a/skills/next-model-local-storage-connector/SKILL.md
+++ b/skills/next-model-local-storage-connector/SKILL.md
@@ -68,15 +68,24 @@ Existing call sites without `{ schema }` keep working unchanged.
 ## Quick start
 
 ```ts
-import { Model } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
 import { LocalStorageConnector } from '@next-model/local-storage-connector';
 
-const connector = new LocalStorageConnector();
+const schema = defineSchema({
+  notes: {
+    columns: {
+      id:    { type: 'integer', primary: true, autoIncrement: true },
+      title: { type: 'string' },
+      body:  { type: 'string' },
+    },
+  },
+});
+
+const connector = new LocalStorageConnector({}, { schema });
 
 class Note extends Model({
-  tableName: 'notes',
   connector,
-  init: (props: { title: string; body: string }) => props,
+  tableName: 'notes',
 }) {}
 
 await Note.create({ title: 'Hello', body: 'world' });

--- a/skills/next-model-mariadb-connector/SKILL.md
+++ b/skills/next-model-mariadb-connector/SKILL.md
@@ -53,15 +53,24 @@ The constructor signature, pool config, and runtime API are otherwise identical 
 ## Quick start
 
 ```ts
-import { Model } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
 import { MariaDbConnector } from '@next-model/mariadb-connector';
 
-const connector = new MariaDbConnector('mariadb://root:mariadb@127.0.0.1:3306/myapp');
+const schema = defineSchema({
+  users: {
+    columns: {
+      id:   { type: 'integer', primary: true, autoIncrement: true },
+      name: { type: 'string' },
+      age:  { type: 'integer' },
+    },
+  },
+});
+
+const connector = new MariaDbConnector('mariadb://root:mariadb@127.0.0.1:3306/myapp', { schema });
 
 class User extends Model({
-  tableName: 'users',
   connector,
-  init: (props: { name: string; age: number }) => props,
+  tableName: 'users',
 }) {}
 
 // One round-trip — INSERT ... RETURNING *.

--- a/skills/next-model-mongodb-connector/SKILL.md
+++ b/skills/next-model-mongodb-connector/SKILL.md
@@ -76,16 +76,25 @@ const connector = new MongoDbConnector({ url: process.env.MONGODB_URL }, { schem
 ## Quick start
 
 ```ts
-import { Model } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
 import { MongoDbConnector } from '@next-model/mongodb-connector';
 
-const connector = new MongoDbConnector({ url: process.env.MONGODB_URL });
+const schema = defineSchema({
+  notes: {
+    columns: {
+      id:    { type: 'integer', primary: true, autoIncrement: true },
+      title: { type: 'string' },
+      body:  { type: 'string' },
+    },
+  },
+});
+
+const connector = new MongoDbConnector({ url: process.env.MONGODB_URL }, { schema });
 await connector.connect();
 
 class Note extends Model({
-  tableName: 'notes',
   connector,
-  init: (props: { title: string; body: string }) => props,
+  tableName: 'notes',
 }) {}
 ```
 

--- a/skills/next-model-mysql-connector/SKILL.md
+++ b/skills/next-model-mysql-connector/SKILL.md
@@ -76,15 +76,24 @@ Existing call sites without `{ schema }` keep working unchanged.
 ## Quick start
 
 ```ts
-import { Model } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
 import { MysqlConnector } from '@next-model/mysql-connector';
 
-const connector = new MysqlConnector(process.env.DATABASE_URL!);
+const schema = defineSchema({
+  users: {
+    columns: {
+      id:   { type: 'integer', primary: true, autoIncrement: true },
+      name: { type: 'string' },
+      age:  { type: 'integer' },
+    },
+  },
+});
+
+const connector = new MysqlConnector(process.env.DATABASE_URL!, { schema });
 
 class User extends Model({
-  tableName: 'users',
   connector,
-  init: (props: { name: string; age: number }) => props,
+  tableName: 'users',
 }) {}
 ```
 

--- a/skills/next-model-postgres-connector/SKILL.md
+++ b/skills/next-model-postgres-connector/SKILL.md
@@ -72,15 +72,24 @@ Existing call sites without `{ schema }` keep working unchanged.
 ## Quick start
 
 ```ts
-import { Model } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
 import { PostgresConnector } from '@next-model/postgres-connector';
 
-const connector = new PostgresConnector(process.env.DATABASE_URL!);
+const schema = defineSchema({
+  users: {
+    columns: {
+      id:   { type: 'integer', primary: true, autoIncrement: true },
+      name: { type: 'string' },
+      age:  { type: 'integer' },
+    },
+  },
+});
+
+const connector = new PostgresConnector(process.env.DATABASE_URL!, { schema });
 
 class User extends Model({
-  tableName: 'users',
   connector,
-  init: (props: { name: string; age: number }) => props,
+  tableName: 'users',
 }) {}
 ```
 

--- a/skills/next-model-redis-connector/SKILL.md
+++ b/skills/next-model-redis-connector/SKILL.md
@@ -54,16 +54,25 @@ The underlying client is exposed as `connector.client`. Pass a `DatabaseSchema` 
 ## Quick start
 
 ```ts
-import { Model } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
 import { RedisConnector } from '@next-model/redis-connector';
 
-const connector = new RedisConnector({ client: { url: process.env.REDIS_URL } });
+const schema = defineSchema({
+  notes: {
+    columns: {
+      id:    { type: 'integer', primary: true, autoIncrement: true },
+      title: { type: 'string' },
+      body:  { type: 'string' },
+    },
+  },
+});
+
+const connector = new RedisConnector({ client: { url: process.env.REDIS_URL } }, { schema });
 await connector.connect();
 
 class Note extends Model({
-  tableName: 'notes',
   connector,
-  init: (props: { title: string; body: string }) => props,
+  tableName: 'notes',
 }) {}
 
 await Note.create({ title: 'Hello', body: 'world' });

--- a/skills/next-model-sqlite-connector/SKILL.md
+++ b/skills/next-model-sqlite-connector/SKILL.md
@@ -82,15 +82,24 @@ const connector = new SqliteConnector(':memory:', { schema });
 ## Quick start
 
 ```ts
-import { Model } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
 import { SqliteConnector } from '@next-model/sqlite-connector';
 
-const connector = new SqliteConnector('./data/app.sqlite');
+const schema = defineSchema({
+  users: {
+    columns: {
+      id:   { type: 'integer', primary: true, autoIncrement: true },
+      name: { type: 'string' },
+      age:  { type: 'integer' },
+    },
+  },
+});
+
+const connector = new SqliteConnector('./data/app.sqlite', { schema });
 
 class User extends Model({
-  tableName: 'users',
   connector,
-  init: (props: { name: string; age: number }) => props,
+  tableName: 'users',
 }) {}
 ```
 

--- a/skills/next-model-typebox/SKILL.md
+++ b/skills/next-model-typebox/SKILL.md
@@ -35,34 +35,51 @@ Peer dependency: `@sinclair/typebox` `^0.34.0` (needs `Value.Default` and stable
 ## Quick start
 
 ```ts
-import { Model, SqliteConnector } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
+import { SqliteConnector } from '@next-model/sqlite-connector';
 import { fromTypeBox } from '@next-model/typebox';
 import { Type } from '@sinclair/typebox';
 
 const UserSchema = Type.Object({
-  name: Type.String({ minLength: 2 }),
-  age: Type.Integer({ minimum: 0 }),
-  active: Type.Boolean({ default: true }),
+  name:     Type.String({ minLength: 2 }),
+  age:      Type.Integer({ minimum: 0 }),
+  active:   Type.Boolean({ default: true }),
   metadata: Type.Optional(Type.Object({ source: Type.String() })),
 });
 
-const user = fromTypeBox(UserSchema);
-const connector = new SqliteConnector(':memory:');
+const bridge = fromTypeBox(UserSchema);
+
+const schema = defineSchema({
+  users: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      ...bridge.toTypedColumns(),   // name, age, active, metadata columns
+    },
+  },
+});
+
+const connector = new SqliteConnector(':memory:', { schema });
 
 class User extends Model({
-  tableName: 'users',
   connector,
-  init: user.init,
-  validators: user.validators,
+  tableName: 'users',
+  init:       bridge.init,
+  validators: bridge.validators,
 }) {}
-
-await connector.createTable('users', (t) => {
-  t.integer('id', { primary: true, autoIncrement: true, null: false });
-  user.applyColumns(t);
-});
 ```
 
-`fromTypeBox(schema)` returns `{ init, validators, applyColumns }`. Pass `init` and `validators` straight into `Model({...})`, and call `applyColumns(t)` inside the `createTable` callback to register every TypeBox property as a column.
+`fromTypeBox(schema)` returns `{ init, validators, applyColumns, toTypedColumns }`. Use `toTypedColumns()` to plug into `defineSchema`, and wire `init` + `validators` into `Model({...})`.
+
+### Using `applyColumns` for migrations
+
+`applyColumns(t)` is still useful inside `connector.createTable(...)` migration callbacks — the `defineTable` builder is imperative and operates independently from `defineSchema`:
+
+```ts
+await connector.createTable('users', (t) => {
+  t.integer('id', { primary: true, autoIncrement: true, null: false });
+  bridge.applyColumns(t);
+});
+```
 
 ## Type mapping
 

--- a/skills/next-model-valkey-connector/SKILL.md
+++ b/skills/next-model-valkey-connector/SKILL.md
@@ -47,18 +47,27 @@ const connector = new ValkeyConnector({ client: { url: '...' } }, { schema });
 ## Quick start
 
 ```ts
-import { Model } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
 import { ValkeyConnector } from '@next-model/valkey-connector';
+
+const schema = defineSchema({
+  users: {
+    columns: {
+      id:   { type: 'integer', primary: true, autoIncrement: true },
+      name: { type: 'string' },
+    },
+  },
+});
 
 const connector = new ValkeyConnector({
   client: { url: 'valkey://127.0.0.1:6379' },
-});
+}, { schema });
 await connector.connect();
 
-const User = Model({ connector, tableName: 'users' });
+class User extends Model({ connector, tableName: 'users' }) {}
 
-await User.create({ id: '1', name: 'Ada' });
-const ada = await User.find({ id: '1' });
+const ada = await User.create({ name: 'Ada' });
+await User.find(ada.id);
 ```
 
 ## Differences from RedisConnector

--- a/skills/next-model-zod/SKILL.md
+++ b/skills/next-model-zod/SKILL.md
@@ -22,7 +22,7 @@ metadata:
 
 - You author schemas with [TypeBox](https://github.com/sinclairzx81/typebox) — use the `next-model-typebox` bridge.
 - You author schemas with [arktype](https://arktype.io) — use the `next-model-arktype` bridge.
-- You only have a plain TypeScript `interface` / type and don't need run-time checking — pass it directly via `Model<Interface>({...})` from `@next-model/core` (see `next-model-core`).
+- You only have a plain TypeScript `interface` / type and don't need run-time checking — use `defineSchema({ table: { columns: {...} } })` from `@next-model/core` directly (see `next-model-core`).
 
 ## Install
 
@@ -36,36 +36,51 @@ pnpm add @next-model/zod zod
 ## Quick start
 
 ```ts
-import { Model, SqliteConnector } from '@next-model/core';
+import { defineSchema, Model } from '@next-model/core';
+import { SqliteConnector } from '@next-model/sqlite-connector';
 import { fromZod } from '@next-model/zod';
 import { z } from 'zod';
 
 const UserSchema = z.object({
-  name: z.string().min(2),
-  age: z.number().int().nonnegative(),
-  active: z.boolean().default(true),
+  name:     z.string().min(2),
+  age:      z.number().int().nonnegative(),
+  active:   z.boolean().default(true),
   metadata: z.object({ source: z.string() }).optional(),
 });
 
-const user = fromZod(UserSchema);
-const connector = new SqliteConnector(':memory:');
+const bridge = fromZod(UserSchema);
+
+const schema = defineSchema({
+  users: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      ...bridge.toTypedColumns(),   // name, age, active, metadata columns
+    },
+  },
+});
+
+const connector = new SqliteConnector(':memory:', { schema });
 
 class User extends Model({
-  tableName: 'users',
   connector,
-  init: user.init,              // parses + throws ValidationError on failure
-  validators: user.validators,   // same schema gates save() / isValid()
+  tableName: 'users',
+  init:       bridge.init,        // parses + throws ValidationError on failure
+  validators: bridge.validators,  // same schema gates save() / isValid()
 }) {}
-
-// Same schema drives the migration — no drift between parse-time types and
-// the DDL that backs them.
-await connector.createTable('users', (t) => {
-  t.integer('id', { primary: true, autoIncrement: true, null: false });
-  user.applyColumns(t);         // adds name, age, active, metadata columns
-});
 ```
 
-`fromZod(schema)` returns `{ init, validators, applyColumns }`. Wire `init` and `validators` into `Model({...})`, and call `applyColumns(t)` inside a `createTable` callback to emit one column per top-level field.
+`fromZod(schema)` returns `{ init, validators, applyColumns, toTypedColumns }`. Use `toTypedColumns()` to plug into `defineSchema`, and wire `init` + `validators` into `Model({...})`.
+
+### Using `applyColumns` for migrations
+
+`applyColumns(t)` is still useful inside `connector.createTable(...)` migration callbacks — the `defineTable` builder is imperative and operates independently from `defineSchema`:
+
+```ts
+await connector.createTable('users', (t) => {
+  t.integer('id', { primary: true, autoIncrement: true, null: false });
+  bridge.applyColumns(t);   // adds name, age, active, metadata columns
+});
+```
 
 ## Type mapping
 

--- a/skills/next-model/SKILL.md
+++ b/skills/next-model/SKILL.md
@@ -60,7 +60,7 @@ This skill is the **index**. For deep package docs, switch to the per-package sk
 | TypeBox | `@next-model/typebox` | `next-model-typebox` |
 | arktype | `@next-model/arktype` | `next-model-arktype` |
 
-> All three bridges convert one schema into `init`, `validators`, **and** `createTable` columns — single source of truth.
+> All three bridges convert one schema into `toTypedColumns()` (for `defineSchema`), `init` coercion, **and** `validators` — single source of truth.
 
 ### Frontend hooks
 
@@ -79,14 +79,23 @@ This skill is the **index**. For deep package docs, switch to the per-package sk
 ## Minimum example
 
 ```ts
-import { Model, MemoryConnector } from '@next-model/core';
+import { defineSchema, Model, MemoryConnector } from '@next-model/core';
 
-const connector = new MemoryConnector({ storage: {} });
+const schema = defineSchema({
+  users: {
+    columns: {
+      id:   { type: 'integer', primary: true, autoIncrement: true },
+      name: { type: 'string' },
+      age:  { type: 'integer' },
+    },
+  },
+});
+
+const connector = new MemoryConnector({ storage: {} }, { schema });
 
 class User extends Model({
-  tableName: 'users',
   connector,
-  init: (props: { name: string; age: number }) => props,
+  tableName: 'users',
 }) {}
 
 await User.create({ name: 'Ada', age: 36 });


### PR DESCRIPTION
## Summary

Brings the root README and the 21 SKILL.md files under \`skills/\` in line with the schema-first Model API that landed via #171/#172/#173. Without this, AI agents driven by the skills emit code using the legacy \`Model({ tableName, init, keys })\` pattern that no longer compiles.

## What changed

**Root \`README.md\`** (\`75fa737\`)
- Quick-start replaced: \`defineSchema\` block → \`SqliteConnector(':memory:', { schema })\` → \`Model({ connector, tableName })\`
- Schema bridge bullet now mentions \`toTypedColumns()\` alongside \`init\` / \`validators\`

**21 \`skills/<name>/SKILL.md\` files** (\`66df106\`)
- 17 files updated; 4 (\`migrations\`, \`migrations-generator\`, \`react\`, \`nextjs-api\`) had no Model constructor patterns
- ~25 legacy code samples migrated:
  - Identity \`init: (props: T) => props\` dropped (schema-derived default-init covers it)
  - \`keys: { id: KeyType.number }\` dropped (derived from schema's \`primary: true\` columns)
  - Connector instantiation: every example that builds a Model now passes \`{ schema }\` as second arg
  - Model-level \`associations: { posts: { hasMany: () => Post } }\` thunks moved into the schema as string-based table refs
  - \`Model<UserProps>(...)\` interface-generic syntax removed (overload was deleted)
- **\`next-model-core\`** got the largest rewrite: collapsed the three-idiom section into a single authoritative schema-first walkthrough; added \`ModelRegistry\` declaration-merging docs; updated soft-delete, validators, callbacks, and association examples
- **Bridge skills** (\`zod\`, \`typebox\`, \`arktype\`): quick-start now leads with \`bridge.toTypedColumns()\` plugged into \`defineSchema\`. \`bridge.applyColumns()\` kept as a secondary "use in migrations" subsection since the imperative \`defineTable\` API is still the right tool for DDL files

## Audit

- Search for legacy \`Model<…Props>(…)\` interface-generic syntax: 0 matches
- Search for identity \`init: (props: T) => props\` in skills: 0 matches  
- Search for Model-level \`associations: {\` in skills: only 2 hits, both inside \`defineSchema(...)\` (schema-level) in the next-model-core associations example

## Test plan

- [x] Root README quick-start example uses only types/methods that exist in the v1.0.0-rc.5 API
- [x] Every skill's quick-start example has been migrated; spot-checked the connector skills, bridge skills, and the core skill
- [x] Docs-only change — no source-code modifications, full test suite + typecheck unaffected