### PR TITLE
feat(core,connectors): add ensureSchema() to materialise schema tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,24 @@ class User extends Model({
   }
 }
 
-await User.createTable();
+await connector.ensureSchema();  // creates every declared table that doesn't exist
 const ada = await User.create({ firstName: 'Ada', lastName: 'Lovelace', age: 36 });
 ada.name; // 'Ada Lovelace'
 ```
 
 Models are TypeScript classes — add getters, methods, and computed properties just like normal. Swap `SqliteConnector` for any other connector ([Postgres](./packages/postgres-connector), [MySQL](./packages/mysql-connector), [MongoDB](./packages/mongodb-connector), [Redis](./packages/redis-connector), `MemoryConnector` for tests, …) and every Model feature keeps working through the same `Connector` interface.
+
+### Materialise the schema with `ensureSchema()`
+
+When the connector carries an attached schema, `connector.ensureSchema()` walks every table declared on it and creates any table that doesn't already exist. Calling it again is a no-op: existing tables are skipped, only new ones are created. It returns `{ created: string[], existing: string[] }` so you can log the diff.
+
+```ts
+const connector = new SqliteConnector('./data/app.sqlite', { schema });
+const { created, existing } = await connector.ensureSchema();
+// app boot: creates missing tables; subsequent boots: returns { created: [], existing: [...] }
+```
+
+Implemented by `SqliteConnector`, `MemoryConnector`, and `LocalStorageConnector` today; other connectors fall back to the explicit `createTable(name, builder)` loop until they opt in.
 
 ### Query with chainable, immutable scopes
 
@@ -56,6 +68,8 @@ await User.filterBy({ $in: { age: [25, 30, 36] } })
 ```
 
 Operators available on every connector: `$eq` · `$gt` · `$gte` · `$lt` · `$lte` · `$in` · `$notIn` · `$null` · `$notNull` · `$like` · `$ilike` · `$between`. Compose them with `filterBy` / `orFilterBy` / `unfiltered` / `unscoped`. Predeclare reusable filters via `scopes` on the `Model({...})` definition.
+
+Each column-style operator accepts both the nested ORM-style form `filterBy({ col: { $in: [...] } })` and the top-level form `filterBy({ $in: { col: [...] } })` — they produce the same query. Operators and equality keys can also be mixed in a single filter object: `filterBy({ workspaceId: 1, $null: 'archivedAt' })` is composed as an AND of every predicate, no `.filterBy(...).filterBy(...)` chaining required.
 
 ### Use it from React
 

--- a/packages/core/HISTORY.md
+++ b/packages/core/HISTORY.md
@@ -2,6 +2,18 @@
 
 ## vNext
 
+### Added
+
+- `Connector.ensureSchema()` is now declared on the `Connector` interface as an optional method. Calling it on a connector with an attached schema iterates `schema.tableDefinitions`, dispatches every missing table through the connector's existing `createTable` path, and returns `{ created: string[]; existing: string[] }` — no more boilerplate that walks `Object.keys(schema.tableDefinitions)` and translates columns + indexes back into the builder DSL. Implemented on `MemoryConnector` (and inherited by `LocalStorageConnector`); third-party connectors stay compilable because the method is optional.
+- `ValidationError` now formats its `.message` as `"Validation failed: <field>: <reason>; <field>: <reason>"` synthesised from the structured `.errors` payload, so test assertions like `expect(p).rejects.toThrow(/name/)` and `instanceOf(ValidationError)` checks pass without inspecting the rejected instance. The new single-argument shape `new ValidationError(errors)` is supported alongside the existing two-arg shape; plain-string callers (no errors map) keep the previous bare message.
+- The Model factory now publishes the resolved schema's column list on the subclass as `static schemaColumnNames` (read by the instance constructor — see below).
+
+### Changed
+
+- Mixed-object filter shapes now compose correctly. `filterBy({ workspaceId: 1, $null: 'archivedAt' })` used to silently drop the equality predicate because the connector's `compileFilter` short-circuits on the first `$`-prefixed key it sees. `normalizeFilterShape` now lifts every top-level operator out into its own AND-piece, so equality + `$null` / `$in` / `$gt` / `$and` / `$or` / column-op maps all coexist in a single filter object and survive end-to-end through every connector. Single-operator and pure-equality shapes are unchanged.
+- Nested column-op syntax (`filterBy({ col: { $in: [...] } })`) and the legacy top-level syntax (`filterBy({ $in: { col: [...] } })`) are now explicitly pinned as equivalent — `normalizeFilterShape` already rewrote one to the other, the test surface just makes the contract load-bearing so future refactors can't silently regress.
+- Property getters on Model instances are now installed for every column declared on the schema's `tableDefinition`, not only the keys present in `persistentProps` at construction. Columns omitted at insert (e.g. nullable timestamps like `archivedAt`) are now readable as `instance.col` immediately after `instance.update({ col: value })` — no more `Model.findBy({ id })` re-fetch dance. Legacy Model paths without `defineSchema` still fall back to the previous `persistentProps`-driven loop.
+
 ## v1.1.0
 
 ## v1.0.0

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -356,6 +356,19 @@ await User.filterBy({ gender: 'male' }).buildScoped({ firstName: 'Joe' });
 await User.filterBy({ gender: 'female' }).createScoped({ firstName: 'Sally' });
 ```
 
+### Property accessors for every schema column
+
+Property getters / setters are installed for every column declared on the Model's schema — not just the columns supplied at `create({ ... })` time. So a `Model.create({ name: 'x' })` on a table that has a nullable `archivedAt` column produces an instance whose `archivedAt` getter exists from construction. A later `instance.update({ archivedAt: new Date() })` makes `instance.archivedAt` immediately readable without a re-fetch:
+
+```ts
+const item = await Item.create({ name: 'x' });    // archivedAt omitted
+item.archivedAt;                                  // undefined (getter exists)
+await item.update({ archivedAt: new Date() });
+item.archivedAt;                                  // Date — no Model.findBy needed
+```
+
+Columns absent from the schema (legacy / dynamic) still fall through to the runtime `persistentProps` keys, preserving behaviour for callers that never went through `defineSchema(...)`.
+
 ## Saving and updating
 
 ```ts
@@ -712,6 +725,35 @@ All comparison keys start with `$`:
 | `$like` | `filterBy({ $like: { email: '%@example.com' } })` |
 | `$async` | `filterBy({ $async: somePromiseResolvingToAFilter })` |
 | `$raw` | connector-specific raw SQL + bindings |
+
+#### Two equivalent shapes per column operator
+
+Every column-style operator (`$in`, `$notIn`, `$gt`, `$gte`, `$lt`, `$lte`, `$like`, `$between`, `$notBetween`, `$not`) accepts both the nested ORM-style form and the legacy top-level form. The two compile to the same query:
+
+```ts
+// Nested form (matches the shape most popular ORMs use).
+User.filterBy({ age: { $gt: 18 } });
+User.filterBy({ status: { $in: ['open', 'pending'] } });
+
+// Top-level form (equivalent).
+User.filterBy({ $gt: { age: 18 } });
+User.filterBy({ $in: { status: ['open', 'pending'] } });
+```
+
+#### Mixed-object filters compose with AND
+
+A single filter object can mix plain column equality with top-level operator keys and composition ops (`$and`, `$or`). Every entry is ANDed together; you don't need to chain `.filterBy(...).filterBy(...)` to keep them all alive:
+
+```ts
+// All three predicates apply.
+await User.filterBy({
+  workspaceId: 1,             // equality
+  $null: 'archivedAt',        // top-level operator
+  age: { $gt: 18 },           // column-op map (rewritten internally)
+}).all();
+```
+
+Without this composition step, the connector's `compileFilter` short-circuits on the first `$`-prefixed key it sees and silently drops the rest — `normalizeFilterShape` wraps mixed shapes in `$and` so every predicate survives.
 
 ### Subquery filter values
 
@@ -1396,6 +1438,18 @@ Any object implementing the `Connector` interface works. The package ships with:
 
 Writing your own is mostly a matter of mapping `Scope` to your driver's query builder. See `packages/knex-connector` or `packages/aurora-data-api-connector` for full examples.
 
+### `ensureSchema()`
+
+Connectors that carry an attached schema can implement the optional `ensureSchema()` method on the interface. It iterates the schema's `tableDefinitions` and creates every missing table idempotently, returning `{ created: string[], existing: string[] }`:
+
+```ts
+const connector = new MemoryConnector({}, { schema });
+const { created } = await connector.ensureSchema();
+// created → ['users', 'posts', ...]
+```
+
+`MemoryConnector`, `LocalStorageConnector` (inherits from `MemoryConnector`), and `SqliteConnector` implement `ensureSchema` today. Other connectors fall back to the original explicit `createTable(name, builder)` loop, and can opt in without a coordinated breaking change because the method is declared optional on `Connector`.
+
 ## Errors
 
 All errors extend `NextModelError` so you can catch them with a single check:
@@ -1403,8 +1457,29 @@ All errors extend `NextModelError` so you can catch them with a single check:
 - `NextModelError` — base class
 - `NotFoundError` — thrown by `find`, `findOrFail`, `save` (when update target vanished)
 - `PersistenceError` — connector-level insert/update/delete failures, or actions on unsaved records
-- `ValidationError` — thrown by `save` when any validator returns false
+- `ValidationError` — thrown by `save` when any validator returns false. Carries `.errors: Record<string, string[]>` mirroring the rejected instance's `errors.toJSON()`; its `.message` is formatted `"Validation failed: <field>: <reason>; <field>: <reason>"` so `expect(p).rejects.toThrow(/name/)` works.
 - `FilterError` — malformed filter expressions
+
+```ts
+import { ValidationError } from '@next-model/core';
+
+try {
+  await User.create({}); // missing required name + email
+} catch (e) {
+  if (e instanceof ValidationError) {
+    console.error(e.message);          // "Validation failed: name: cannot be blank; email: cannot be blank"
+    console.error(e.errors?.name);     // ["cannot be blank"]
+  }
+  throw e;
+}
+```
+
+Two construction shapes are accepted, mirrored both in tests and consumer code:
+
+```ts
+new ValidationError(errorsMap);                       // one-arg form
+new ValidationError('Validation failed', errorsMap);  // legacy two-arg form
+```
 
 ## Changelog
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,8 +30,7 @@
   "files": [
     "dist",
     "!dist/**/__tests__",
-    "!dist/**/__benchmark__",
-    "!dist/**/*.map"
+    "!dist/**/__benchmark__"
   ],
   "repository": {
     "type": "git",

--- a/packages/core/src/FilterEngine.ts
+++ b/packages/core/src/FilterEngine.ts
@@ -71,58 +71,78 @@ function isColumnOpMap(value: unknown): value is Record<string, unknown> {
 export function normalizeFilterShape<T extends Filter<any>>(filter: T): T {
   if (!isPlainObject(filter)) return filter;
 
-  const normalized: Record<string, unknown> = {};
+  // Plain column equality. These all coexist fine in a single object via the
+  // connector's `compileEquality` path, so we collect them together.
+  const equality: Record<string, unknown> = {};
+
+  // Each entry here becomes one AND-piece in the final wrapper. Top-level
+  // operators (`$null`, `$in`, `$gt`, `$and`, `$or`, `$not`, `$raw`,
+  // `$async`, ...) cannot coexist with each other or with equality in a
+  // single object — every connector's `compileFilter` short-circuits on the
+  // first operator it recognises and silently drops siblings. We split each
+  // one into its own AND-piece so the wrapper preserves the user's intent.
   const andPieces: unknown[] = [];
 
   for (const [key, value] of Object.entries(filter)) {
     if (COMPOSITION_OPS.has(key)) {
       if (key === '$and' || key === '$or') {
-        normalized[key] = (value as unknown[]).map((child) =>
-          normalizeFilterShape(child as Filter<any>),
-        );
+        andPieces.push({
+          [key]: (value as unknown[]).map((child) => normalizeFilterShape(child as Filter<any>)),
+        });
       } else if (key === '$not') {
-        normalized[key] = isPlainObject(value) ? normalizeFilterShape(value as Filter<any>) : value;
+        andPieces.push({
+          [key]: isPlainObject(value) ? normalizeFilterShape(value as Filter<any>) : value,
+        });
       } else {
-        normalized[key] = value;
+        andPieces.push({ [key]: value });
       }
       continue;
     }
 
     if (key.startsWith('$')) {
-      // Legacy `{$op: {col: v}}` — leave as-is.
-      normalized[key] = value;
+      // Top-level column operator (`$null`, `$in`, `$gt`, ...). Treat as its
+      // own AND-piece so it can safely coexist with sibling equality or
+      // other operators in the original filter.
+      andPieces.push({ [key]: value });
       continue;
     }
 
     if (isColumnOpMap(value)) {
       const ops = value as Record<string, unknown>;
       const opKeys = Object.keys(ops);
-      if (opKeys.length === 1) {
-        const op = opKeys[0];
-        normalized[op] ??= {} as Record<string, unknown>;
-        (normalized[op] as Record<string, unknown>)[key] = ops[op];
-      } else {
-        for (const op of opKeys) {
-          andPieces.push({ [op]: { [key]: ops[op] } });
-        }
+      for (const op of opKeys) {
+        andPieces.push({ [op]: { [key]: ops[op] } });
       }
       continue;
     }
 
     // Plain equality (possibly against a nested object literal — kept unchanged).
-    normalized[key] = value;
+    equality[key] = value;
   }
 
-  if (andPieces.length > 0) {
-    const existing = Object.keys(normalized);
-    if (existing.length === 0 && andPieces.length === 1) {
-      return andPieces[0] as T;
-    }
-    const rest = existing.length > 0 ? [normalized] : [];
-    return { $and: [...rest, ...andPieces] } as unknown as T;
+  // Decide the simplest equivalent shape because downstream code paths
+  // (lower, walkFilter, defaultScope pruning, the connector fast paths) all
+  // already special-case the flat form.
+  const equalityKeys = Object.keys(equality);
+
+  // No top-level operators were present — keep the flat equality shape so
+  // the connector's `compileEquality` fast path applies unchanged. (Empty
+  // object is also returned here — it is a no-op filter.)
+  if (andPieces.length === 0) return equality as T;
+
+  // Exactly one piece and no equality — return the single piece directly so
+  // single-operator filters keep their established shape (no spurious
+  // `$and` wrapper that would break callers / pretty-printers).
+  if (equalityKeys.length === 0 && andPieces.length === 1) {
+    return andPieces[0] as T;
   }
 
-  return normalized as T;
+  // Mixed form: wrap everything in $and. Equality (if any) is a single AND
+  // piece so the connector's compileEquality fast path still applies inside.
+  const wrapped: unknown[] = [];
+  if (equalityKeys.length > 0) wrapped.push(equality);
+  for (const piece of andPieces) wrapped.push(piece);
+  return { $and: wrapped } as unknown as T;
 }
 
 async function propertyFilter(items: Dict<any>[], filter: Dict<any>): Promise<Dict<any>[]> {

--- a/packages/core/src/MemoryConnector.ts
+++ b/packages/core/src/MemoryConnector.ts
@@ -1,7 +1,13 @@
 import { UnsupportedOperationError } from './errors.js';
 import { filterList } from './FilterEngine.js';
 import { baseQueryScoped } from './query/baseQueryScoped.js';
-import { type AlterTableSpec, defineTable, type TableBuilder } from './schema.js';
+import {
+  type AlterTableSpec,
+  type ColumnOptions,
+  defineTable,
+  type IndexOptions,
+  type TableBuilder,
+} from './schema.js';
 import type { DatabaseSchema } from './typedSchema.js';
 import {
   type AggregateKind,
@@ -245,6 +251,57 @@ export class MemoryConnector<S extends DatabaseSchema<any> | undefined = undefin
     if (!Object.hasOwn(this.storage, tableName)) {
       this.storage[tableName] = [];
     }
+  }
+
+  /**
+   * Materialise every table declared in the attached `schema` idempotently.
+   * Iterates `schema.tableDefinitions` and dispatches through the existing
+   * per-connector `createTable` path so connector-specific column type quirks
+   * are preserved. Subclasses (e.g. SQLite, localStorage) inherit this method
+   * — they only need to ensure their `createTable` / `hasTable` overrides are
+   * sound.
+   */
+  async ensureSchema(): Promise<{ created: string[]; existing: string[] }> {
+    if (!this.schema) {
+      throw new Error(
+        'Connector.ensureSchema(): no schema is attached. Pass `{ schema }` at construction.',
+      );
+    }
+    const created: string[] = [];
+    const existing: string[] = [];
+    const tableDefinitions = this.schema.tableDefinitions as Record<
+      string,
+      import('./schema.js').TableDefinition
+    >;
+    for (const tableName of Object.keys(tableDefinitions)) {
+      if (await this.hasTable(tableName)) {
+        existing.push(tableName);
+        continue;
+      }
+      const def = tableDefinitions[tableName];
+      await this.createTable(tableName, (t) => {
+        for (const col of def.columns) {
+          const options: ColumnOptions = {
+            null: col.nullable,
+            primary: col.primary,
+            unique: col.unique,
+            autoIncrement: col.autoIncrement,
+          };
+          if (col.default !== undefined) options.default = col.default;
+          if (col.limit !== undefined) options.limit = col.limit;
+          if (col.precision !== undefined) options.precision = col.precision;
+          if (col.scale !== undefined) options.scale = col.scale;
+          t.column(col.name, col.type, options);
+        }
+        for (const idx of def.indexes) {
+          const indexOptions: IndexOptions = { unique: idx.unique };
+          if (idx.name !== undefined) indexOptions.name = idx.name;
+          t.index(idx.columns, indexOptions);
+        }
+      });
+      created.push(tableName);
+    }
+    return { created, existing };
   }
 
   async dropTable(tableName: string): Promise<void> {

--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -470,6 +470,18 @@ export type ScopesToMethods<Self, S extends ScopeMap> = {
 
 export class ModelClass {
   static tableName: string;
+  /**
+   * Column names declared on the schema for this Model's table, in the order
+   * they appear in the schema. Used by the instance constructor to install
+   * property getters for every declared column — including columns the
+   * caller omitted at `create({ ... })` time — so that a later
+   * `update({ col: value })` makes `instance.col` readable without a
+   * re-fetch.
+   *
+   * Defaults to an empty array for legacy code paths that build a Model
+   * without going through the schema-driven `Model()` factory.
+   */
+  static schemaColumnNames: readonly string[] = [];
   static filter: Filter<any> | undefined;
   /**
    * Sticky filter applied to every chained read on the Model. Unlike
@@ -1493,15 +1505,33 @@ export class ModelClass {
     this.persistentProps = props;
     this.keys = keys;
 
-    for (const key in this.persistentProps) {
+    const model = this.constructor as typeof ModelClass;
+
+    // Install getters / setters for every column declared on the Model's
+    // schema. Iterating only `persistentProps` would miss columns the caller
+    // omitted at insert (e.g. nullable timestamps like `archivedAt`) — a
+    // later `instance.update({ archivedAt: new Date() })` would store the
+    // value but `instance.archivedAt` would still read `undefined` until
+    // re-fetched. Falling back to `persistentProps` keeps the previous
+    // behaviour for any Model built without a schema column list.
+    const installed = new Set<string>();
+    const schemaCols = model.schemaColumnNames ?? [];
+    for (const key of schemaCols) {
+      installed.add(key);
       Object.defineProperty(this, key, {
         get: () => this.attributes[key],
         set: (value) => this.assign({ [key]: value }),
         configurable: true,
       });
     }
-
-    const model = this.constructor as typeof ModelClass;
+    for (const key in this.persistentProps) {
+      if (installed.has(key)) continue;
+      Object.defineProperty(this, key, {
+        get: () => this.attributes[key],
+        set: (value) => this.assign({ [key]: value }),
+        configurable: true,
+      });
+    }
 
     // Keys are configurable so they can re-define a same-named property
     // installed by the persistentProps loop above (e.g. when the caller
@@ -2441,7 +2471,15 @@ export function Model(props: any): any {
     tableDefinition,
     resolvedSchema.tableDefinitions,
   );
-  const result = modelFactoryImpl({ ...props, tableName, keys, init, associations });
+  const schemaColumnNames = tableDefinition.columns.map((c) => c.name);
+  const result = modelFactoryImpl({
+    ...props,
+    tableName,
+    keys,
+    init,
+    associations,
+    schemaColumnNames,
+  });
   ModelClass.tableRegistry.set(tableName, result as unknown as typeof ModelClass);
   return result;
 }
@@ -2485,6 +2523,16 @@ function modelFactoryImpl<
   secureTokens?: string[] | Dict<{ length?: number }>;
   counterCaches?: CounterCacheSpec[];
   associations?: AssociationsMap;
+  /**
+   * Column names declared on the schema's `tableDefinition` for this model.
+   * The instance constructor uses this list to pre-install property getters
+   * for every declared column — including those that are absent at insert
+   * time (nullable columns, defaults supplied at insert by the DB, ...) —
+   * so a subsequent `update({ col: value })` makes `instance.col` readable
+   * without a re-fetch. Optional so the legacy non-schema-driven Model
+   * factory path stays compilable.
+   */
+  schemaColumnNames?: string[];
 }) {
   const connector = props.connector ? props.connector : new MemoryConnector();
   const order = props.order ? (Array.isArray(props.order) ? props.order : [props.order]) : [];
@@ -2558,6 +2606,7 @@ function modelFactoryImpl<
 
   const ModelSubclass = class Model extends ModelClass {
     static tableName = props.tableName;
+    static schemaColumnNames: readonly string[] = props.schemaColumnNames ?? [];
     static filter = props.filter;
     static defaultScope = props.defaultScope;
     static limit = props.limit;

--- a/packages/core/src/__tests__/ensureSchema.spec.ts
+++ b/packages/core/src/__tests__/ensureSchema.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { defineSchema, MemoryConnector } from '../index.js';
+
+const schema = defineSchema({
+  users: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      email: { type: 'string', null: false, unique: true },
+      name: { type: 'string', null: true },
+    },
+    indexes: [{ columns: ['email'], unique: true }],
+  },
+  posts: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      title: { type: 'string', null: false },
+    },
+  },
+  tags: {
+    columns: {
+      slug: { type: 'string', primary: true },
+    },
+  },
+});
+
+describe('MemoryConnector#ensureSchema', () => {
+  it('creates every table declared on the attached schema', async () => {
+    const connector = new MemoryConnector({ storage: {}, lastIds: {} }, { schema });
+    const result = await connector.ensureSchema();
+    expect(result.created.sort()).toEqual(['posts', 'tags', 'users']);
+    expect(result.existing).toEqual([]);
+    expect(await connector.hasTable('users')).toBe(true);
+    expect(await connector.hasTable('posts')).toBe(true);
+    expect(await connector.hasTable('tags')).toBe(true);
+  });
+
+  it('is idempotent on a second call', async () => {
+    const connector = new MemoryConnector({ storage: {}, lastIds: {} }, { schema });
+    await connector.ensureSchema();
+    const result = await connector.ensureSchema();
+    expect(result.created).toEqual([]);
+    expect(result.existing.sort()).toEqual(['posts', 'tags', 'users']);
+  });
+
+  it('only creates missing tables when some already exist', async () => {
+    const connector = new MemoryConnector({ storage: {}, lastIds: {} }, { schema });
+    // Pre-create one of the tables manually.
+    await connector.createTable('users', (t) => {
+      t.integer('id', { primary: true, autoIncrement: true });
+    });
+    const result = await connector.ensureSchema();
+    expect(result.existing).toEqual(['users']);
+    expect(result.created.sort()).toEqual(['posts', 'tags']);
+  });
+
+  it('throws when no schema is attached', async () => {
+    const connector = new MemoryConnector({ storage: {}, lastIds: {} });
+    await expect(connector.ensureSchema()).rejects.toThrow(/no schema is attached/);
+  });
+});

--- a/packages/core/src/__tests__/filterShape.spec.ts
+++ b/packages/core/src/__tests__/filterShape.spec.ts
@@ -171,3 +171,83 @@ describe('filterBy accepts both shapes', () => {
     expect(rows.length).toBeGreaterThanOrEqual(0); // parses without throwing
   });
 });
+
+describe('normalizeFilterShape composes mixed-object filters', () => {
+  it('AND-wraps equality + top-level $null', () => {
+    expect(normalizeFilterShape({ status: 'open', $null: 'metadata' })).toEqual({
+      $and: [{ status: 'open' }, { $null: 'metadata' }],
+    });
+  });
+
+  it('AND-wraps equality + top-level $in', () => {
+    expect(normalizeFilterShape({ status: 'open', $in: { age: [10, 20] } })).toEqual({
+      $and: [{ status: 'open' }, { $in: { age: [10, 20] } }],
+    });
+  });
+
+  it('AND-wraps equality + column-op map ($gt)', () => {
+    expect(normalizeFilterShape({ status: 'open', age: { $gt: 18 } })).toEqual({
+      $and: [{ status: 'open' }, { $gt: { age: 18 } }],
+    });
+  });
+
+  it('AND-wraps multiple top-level operators', () => {
+    expect(
+      normalizeFilterShape({
+        $null: 'archivedAt',
+        $notNull: 'reviewedAt',
+      }),
+    ).toEqual({
+      $and: [{ $null: 'archivedAt' }, { $notNull: 'reviewedAt' }],
+    });
+  });
+
+  it('preserves $and alongside equality (composition op is its own piece)', () => {
+    const out = normalizeFilterShape({
+      status: 'open',
+      $and: [{ age: { $gt: 18 } }],
+    });
+    expect(out).toEqual({
+      $and: [{ status: 'open' }, { $and: [{ $gt: { age: 18 } }] }],
+    });
+  });
+});
+
+describe('filterBy composes mixed-object filters end-to-end', () => {
+  it('mixed equality + $null: row in both', async () => {
+    const connector = freshConnector();
+    const Ticket = buildModel(connector);
+    await seed(Ticket);
+    // Make the metadata column null on row B
+    await Ticket.filterBy({ name: 'B' }).updateAll({ metadata: null });
+    const rows = await Ticket.filterBy({ status: 'pending', $null: 'metadata' }).all();
+    // Only B is both pending AND has null metadata; E is pending but has metadata.
+    expect(rows.map((r) => (r.attributes as Row).name)).toEqual(['B']);
+  });
+
+  it('mixed equality + $in: row in both', async () => {
+    const connector = freshConnector();
+    const Ticket = buildModel(connector);
+    await seed(Ticket);
+    const rows = await Ticket.filterBy({
+      status: 'open',
+      $in: { age: [10, 20, 40] },
+    })
+      .orderBy({ key: 'age' })
+      .all();
+    // status=open: A,C. age in 10/20/40: A,C,B. Intersection: A,C.
+    expect(rows.map((r) => (r.attributes as Row).name)).toEqual(['A', 'C']);
+  });
+
+  it('mixed $and + $null still composes correctly', async () => {
+    const connector = freshConnector();
+    const Ticket = buildModel(connector);
+    await seed(Ticket);
+    await Ticket.filterBy({ name: 'B' }).updateAll({ metadata: null });
+    const rows = await Ticket.filterBy({
+      $and: [{ status: 'pending' }],
+      $null: 'metadata',
+    } as any).all();
+    expect(rows.map((r) => (r.attributes as Row).name)).toEqual(['B']);
+  });
+});

--- a/packages/core/src/__tests__/filterShape.spec.ts
+++ b/packages/core/src/__tests__/filterShape.spec.ts
@@ -213,6 +213,49 @@ describe('normalizeFilterShape composes mixed-object filters', () => {
   });
 });
 
+describe('nested $in / $notIn syntax is equivalent to top-level', () => {
+  it('normalizes nested $in into top-level $in (pure)', () => {
+    expect(normalizeFilterShape({ status: { $in: ['open', 'pending'] } })).toEqual({
+      $in: { status: ['open', 'pending'] },
+    });
+  });
+
+  it('normalizes nested $notIn into top-level $notIn (pure)', () => {
+    expect(normalizeFilterShape({ status: { $notIn: ['closed'] } })).toEqual({
+      $notIn: { status: ['closed'] },
+    });
+  });
+
+  it('nested $in matches the same rows as top-level $in', async () => {
+    const connector = freshConnector();
+    const Ticket = buildModel(connector);
+    await seed(Ticket);
+    const nested = await Ticket.filterBy({ status: { $in: ['open', 'pending'] } })
+      .orderBy({ key: 'name' })
+      .all();
+    const topLevel = await Ticket.filterBy({ $in: { status: ['open', 'pending'] } } as any)
+      .orderBy({ key: 'name' })
+      .all();
+    expect(nested.map((r) => (r.attributes as Row).name)).toEqual(
+      topLevel.map((r) => (r.attributes as Row).name),
+    );
+  });
+
+  it('mixed: nested $in + equality (combines with mixed-filter composition)', async () => {
+    const connector = freshConnector();
+    const Ticket = buildModel(connector);
+    await seed(Ticket);
+    // status=open AND age in {10, 20, 40} → A (10/open), C (20/open). B is 40/pending.
+    const rows = await Ticket.filterBy({
+      status: 'open',
+      age: { $in: [10, 20, 40] },
+    })
+      .orderBy({ key: 'age' })
+      .all();
+    expect(rows.map((r) => (r.attributes as Row).name)).toEqual(['A', 'C']);
+  });
+});
+
 describe('filterBy composes mixed-object filters end-to-end', () => {
   it('mixed equality + $null: row in both', async () => {
     const connector = freshConnector();

--- a/packages/core/src/__tests__/schemaPropertyGetters.spec.ts
+++ b/packages/core/src/__tests__/schemaPropertyGetters.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { MemoryConnector } from '../MemoryConnector.js';
+import { Model } from '../Model.js';
+import { defineSchema } from '../typedSchema.js';
+
+describe('Property getters install from schema columns, not insert-time keys', () => {
+  const schema = defineSchema({
+    items: {
+      columns: {
+        id: { type: 'integer', primary: true, autoIncrement: true },
+        name: { type: 'string', null: false },
+        archivedAt: { type: 'datetime', null: true },
+        dismissedAt: { type: 'datetime', null: true },
+        score: { type: 'integer', null: true },
+      },
+    },
+  });
+
+  function makeItem() {
+    const connector = new MemoryConnector({ storage: {} }, { schema });
+    return class Item extends Model({ connector, tableName: 'items', timestamps: false }) {};
+  }
+
+  it('exposes a getter for a nullable column omitted at insert', async () => {
+    const Item = makeItem();
+    const row = await Item.create({ name: 'first' });
+    // archivedAt was never passed to create(); the getter should still exist.
+    const desc = Object.getOwnPropertyDescriptor(row, 'archivedAt');
+    expect(desc).toBeDefined();
+    expect((row as any).archivedAt).toBeUndefined();
+  });
+
+  it('reflects update({ col }) on a previously-absent nullable column without re-fetch', async () => {
+    const Item = makeItem();
+    const row = await Item.create({ name: 'first' });
+    const ts = new Date('2026-01-01T00:00:00.000Z');
+    await row.update({ archivedAt: ts });
+    // The bug: pre-fix, this would read undefined.
+    expect((row as any).archivedAt).toEqual(ts);
+  });
+
+  it('multiple omitted columns all become readable after update', async () => {
+    const Item = makeItem();
+    const row = await Item.create({ name: 'first' });
+    await row.update({
+      archivedAt: new Date('2026-01-02T00:00:00.000Z'),
+      dismissedAt: new Date('2026-01-03T00:00:00.000Z'),
+      score: 7,
+    });
+    expect((row as any).archivedAt).toBeInstanceOf(Date);
+    expect((row as any).dismissedAt).toBeInstanceOf(Date);
+    expect((row as any).score).toBe(7);
+  });
+
+  it('columns supplied at insert still read back through the getter', async () => {
+    const Item = makeItem();
+    const row = await Item.create({
+      name: 'second',
+      archivedAt: new Date('2026-02-01T00:00:00.000Z'),
+    });
+    expect((row as any).name).toBe('second');
+    expect((row as any).archivedAt).toBeInstanceOf(Date);
+  });
+
+  it('setter routes through assign() for schema-installed getters', async () => {
+    const Item = makeItem();
+    const row = await Item.create({ name: 'third' });
+    // Even though archivedAt was not present in persistentProps at construction,
+    // the getter/setter exposed by the schema column should route through
+    // assign() — landing the change in changedProps and making it readable.
+    (row as any).archivedAt = new Date('2026-03-01T00:00:00.000Z');
+    expect((row as any).archivedAt).toBeInstanceOf(Date);
+    expect(row.isChanged()).toBe(true);
+    expect(row.isChangedBy('archivedAt')).toBe(true);
+  });
+});

--- a/packages/core/src/__tests__/validators.spec.ts
+++ b/packages/core/src/__tests__/validators.spec.ts
@@ -290,6 +290,54 @@ describe('validator registry', () => {
         email: ['cannot be blank'],
       });
     });
+
+    it('the thrown error message includes every offending field name', async () => {
+      const User = Model({
+        tableName: 'users',
+        connector: connector(),
+        validators: [validatePresence(['name', 'email'])],
+      });
+      await expect(User.create({} as any)).rejects.toThrow(/name/);
+      await expect(User.create({} as any)).rejects.toThrow(/email/);
+    });
+
+    it('the thrown error message follows "Validation failed: <field>: <reason>" form', async () => {
+      const User = Model({
+        tableName: 'users',
+        connector: connector(),
+        validators: [validatePresence(['name'])],
+      });
+      let thrown: ValidationError | undefined;
+      try {
+        await User.create({} as any);
+      } catch (e) {
+        thrown = e as ValidationError;
+      }
+      expect(thrown).toBeInstanceOf(ValidationError);
+      expect(thrown?.message).toMatch(/^Validation failed:.*name:/);
+      expect(thrown?.message).toContain('cannot be blank');
+    });
+
+    it('accepts the single-argument shape (errors only)', () => {
+      const e = new ValidationError({ name: ['cannot be blank'] });
+      expect(e).toBeInstanceOf(ValidationError);
+      expect(e.errors).toEqual({ name: ['cannot be blank'] });
+      expect(e.message).toMatch(/Validation failed/);
+      expect(e.message).toMatch(/name/);
+    });
+
+    it('preserves the plain string message when no error map is supplied', () => {
+      const e = new ValidationError('something custom');
+      expect(e.message).toBe('something custom');
+      expect(e.errors).toBeUndefined();
+    });
+
+    it('joins multiple reasons per field with a comma', () => {
+      const e = new ValidationError({
+        name: ['cannot be blank', 'must be at least 3 characters'],
+      });
+      expect(e.message).toContain('name: cannot be blank, must be at least 3 characters');
+    });
   });
 
   describe('Errors utility', () => {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -10,10 +10,61 @@ export class NotFoundError extends NextModelError {}
 export class PersistenceError extends NextModelError {}
 export class StaleObjectError extends NextModelError {}
 export class UnsupportedOperationError extends NextModelError {}
+/**
+ * Thrown when `Model#save()` (and the higher-level `create` / `update`
+ * helpers that go through it) fails validation. The structured per-field
+ * payload that lives on the rejected instance's `errors` getter is mirrored
+ * onto `.errors` so callers don't need a reference to the instance just to
+ * inspect what went wrong.
+ *
+ * The `.message` is formatted so that test assertions like
+ * `expect(p).rejects.toThrow(/name/)` work — it contains every field name
+ * that produced a failure plus the first message for that field.
+ */
 export class ValidationError extends NextModelError {
   errors?: Record<string, string[]>;
-  constructor(message: string, errors?: Record<string, string[]>) {
-    super(message);
-    this.errors = errors;
+
+  constructor(
+    messageOrErrors: string | Record<string, string[]>,
+    errors?: Record<string, string[]>,
+  ) {
+    // Two call shapes are supported for backwards compatibility:
+    //   new ValidationError('Validation failed', errorsMap)
+    //   new ValidationError(errorsMap)
+    // The single-argument form is the new ergonomic one. The message is
+    // synthesised from the map so it includes field names.
+    let resolvedErrors: Record<string, string[]> | undefined;
+    let baseMessage: string;
+    if (typeof messageOrErrors === 'string') {
+      baseMessage = messageOrErrors;
+      resolvedErrors = errors;
+    } else {
+      resolvedErrors = messageOrErrors;
+      baseMessage = 'Validation failed';
+    }
+    super(ValidationError.formatMessage(baseMessage, resolvedErrors));
+    this.errors = resolvedErrors;
+  }
+
+  /**
+   * Render a human-readable summary of every field failure, prefixed by the
+   * base message. Returns just the base message when no field errors are
+   * supplied — callers that pass plain strings still get the previous
+   * behaviour.
+   */
+  private static formatMessage(base: string, errors: Record<string, string[]> | undefined): string {
+    if (!errors) return base;
+    const parts: string[] = [];
+    for (const field of Object.keys(errors)) {
+      const reasons = errors[field];
+      if (!reasons || reasons.length === 0) continue;
+      // Show every reason for each field. Joining with `, ` reads naturally
+      // for the common one-reason case ("name: cannot be blank") and stays
+      // legible when a field has multiple ("name: cannot be blank, must be
+      // at least 3 characters").
+      parts.push(`${field}: ${reasons.join(', ')}`);
+    }
+    if (parts.length === 0) return base;
+    return `${base}: ${parts.join('; ')}`;
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -126,6 +126,23 @@ export interface Connector<
   createTable(tableName: string, blueprint: (t: TableBuilder) => void): Promise<void>;
   dropTable(tableName: string): Promise<void>;
   /**
+   * Materialise every table declared in the attached `schema` idempotently.
+   * For each entry in `schema.tableDefinitions`: skip tables that already
+   * exist (added to `existing`); otherwise call `createTable` with the
+   * column + index definitions from the schema (added to `created`).
+   *
+   * Throws when no schema is attached to the connector — `ensureSchema`
+   * is a no-op without one, so the missing schema is treated as a config
+   * error rather than silent success.
+   *
+   * Optional on the interface so connectors that don't need it (recording
+   * wrappers, KV stores without a declared schema, etc.) can leave it
+   * undefined without breaking the contract. Concrete connectors that
+   * accept a schema at construction (memory, sqlite, local-storage, …)
+   * should implement it.
+   */
+  ensureSchema?(): Promise<{ created: string[]; existing: string[] }>;
+  /**
    * Apply a series of mutation ops to an existing table. SQL-shaped connectors
    * implement every op; non-relational connectors (Mongo, Redis, Valkey) may
    * throw `UnsupportedOperationError` for ops they cannot honour.

--- a/packages/local-storage-connector/HISTORY.md
+++ b/packages/local-storage-connector/HISTORY.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+### Added
+
+- `connector.ensureSchema()` is inherited from `MemoryConnector` — when the connector carries a schema (`new LocalStorageConnector(opts, { schema })`), the call walks every declared table and initialises an empty array in `localStorage` for each one that doesn't already exist, returning `{ created, existing }`. Existing rows in other tables are untouched. Throws if no schema is attached.
+- Sourcemap files (`dist/**/*.map`) are now published with the package so downstream bundlers resolve stack frames inside `@next-model/local-storage-connector` to the original TypeScript source. No runtime change.
+
 ## v1.1.0
 
 ## v1.0.0

--- a/packages/local-storage-connector/README.md
+++ b/packages/local-storage-connector/README.md
@@ -50,6 +50,15 @@ const connector = new LocalStorageConnector({ prefix: 'app:' }, { schema });
 
 Existing call sites without `{ schema }` keep working unchanged.
 
+### Materialising tables with `ensureSchema()`
+
+Inherited from `MemoryConnector`: when a schema is attached, `connector.ensureSchema()` iterates every declared table and initialises it idempotently. Returns `{ created, existing }`. Call once on app boot:
+
+```ts
+const connector = new LocalStorageConnector({ prefix: 'app:' }, { schema });
+const { created } = await connector.ensureSchema();
+```
+
 ## Wiring a Model
 
 ```ts

--- a/packages/local-storage-connector/package.json
+++ b/packages/local-storage-connector/package.json
@@ -14,8 +14,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "!dist/**/__tests__",
-    "!dist/**/*.map"
+    "!dist/**/__tests__"
   ],
   "repository": {
     "type": "git",

--- a/packages/local-storage-connector/src/__tests__/ensureSchema.spec.ts
+++ b/packages/local-storage-connector/src/__tests__/ensureSchema.spec.ts
@@ -1,0 +1,69 @@
+import { defineSchema } from '@next-model/core';
+import { describe, expect, it } from 'vitest';
+
+import { MemoryLocalStorage } from '../__mocks__/MemoryLocalStorage.js';
+import { LocalStorageConnector } from '../LocalStorageConnector.js';
+
+const schema = defineSchema({
+  users: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      email: { type: 'string', null: false, unique: true },
+      name: { type: 'string', null: true },
+    },
+    indexes: [{ columns: ['email'], unique: true }],
+  },
+  posts: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      title: { type: 'string', null: false },
+    },
+  },
+  tags: {
+    columns: {
+      slug: { type: 'string', primary: true },
+    },
+  },
+});
+
+describe('LocalStorageConnector#ensureSchema', () => {
+  it('creates every table declared on the attached schema', async () => {
+    const storage = new MemoryLocalStorage();
+    const connector = new LocalStorageConnector({ localStorage: storage }, { schema });
+    const result = await connector.ensureSchema();
+    expect(result.created.sort()).toEqual(['posts', 'tags', 'users']);
+    expect(result.existing).toEqual([]);
+    expect(await connector.hasTable('users')).toBe(true);
+    expect(await connector.hasTable('posts')).toBe(true);
+    expect(await connector.hasTable('tags')).toBe(true);
+    // Each table should have a (possibly empty) JSON entry persisted.
+    expect(storage.getItem('users')).not.toBeNull();
+    expect(storage.getItem('posts')).not.toBeNull();
+    expect(storage.getItem('tags')).not.toBeNull();
+  });
+
+  it('is idempotent on a second call', async () => {
+    const storage = new MemoryLocalStorage();
+    const connector = new LocalStorageConnector({ localStorage: storage }, { schema });
+    await connector.ensureSchema();
+    const result = await connector.ensureSchema();
+    expect(result.created).toEqual([]);
+    expect(result.existing.sort()).toEqual(['posts', 'tags', 'users']);
+  });
+
+  it('rehydrates and recognises previously persisted tables', async () => {
+    const storage = new MemoryLocalStorage();
+    const first = new LocalStorageConnector({ localStorage: storage }, { schema });
+    await first.ensureSchema();
+    // A fresh connector pointed at the same storage should see existing tables.
+    const second = new LocalStorageConnector({ localStorage: storage }, { schema });
+    const result = await second.ensureSchema();
+    expect(result.created).toEqual([]);
+    expect(result.existing.sort()).toEqual(['posts', 'tags', 'users']);
+  });
+
+  it('throws when no schema is attached', async () => {
+    const connector = new LocalStorageConnector({ localStorage: new MemoryLocalStorage() });
+    await expect(connector.ensureSchema()).rejects.toThrow(/no schema is attached/);
+  });
+});

--- a/packages/react/HISTORY.md
+++ b/packages/react/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Added
+
+- Sourcemap files (`dist/**/*.map`) are now included in the published tarball so downstream Vite / webpack / Rollup builds resolve stack frames inside `@next-model/react` to the original TypeScript source — no `ENOENT` warnings for `dist/index.js.map`. No runtime change.
+
 ## v1.1.0
 
 ## v1.0.0

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -151,3 +151,7 @@ import type {
 - No optimistic insertion of newly saved rows into watched arrays — use `useInvalidateKeys`.
 - No interval / background polling.
 - Cross-Provider mutations are not propagated.
+
+## Source maps
+
+`dist/**/*.map` is included in the published tarball, so downstream bundlers (Vite, webpack, esbuild, Rollup) resolve the original TypeScript source on errors out of `@next-model/react` without `ENOENT` warnings. There is no runtime change.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,8 +14,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "!dist/**/__tests__",
-    "!dist/**/*.map"
+    "!dist/**/__tests__"
   ],
   "repository": {
     "type": "git",

--- a/packages/sqlite-connector/HISTORY.md
+++ b/packages/sqlite-connector/HISTORY.md
@@ -2,6 +2,15 @@
 
 ## vNext
 
+### Added
+
+- `connector.ensureSchema()` walks the attached `schema.tableDefinitions` and dispatches every missing table through `createTable`, returning `{ created, existing }` so callers can log what changed. Idempotent: existing tables are reported, not recreated. Throws if no schema is attached.
+- Sourcemap files (`dist/**/*.map`) are now included in the published tarball. Downstream Vite / webpack / Rollup builds resolve stack frames inside `@next-model/sqlite-connector` to original TypeScript source without `ENOENT` warnings. No runtime change.
+
+### Changed
+
+- Boolean columns are coerced to `true` / `false` on read when a schema is attached. SQLite has no native boolean and `better-sqlite3` returns 0 / 1 INTEGER for every column declared `boolean`; the connector now mirrors the existing JSON-column behaviour and coerces 0 / 1 → `false` / `true` inside `hydrateRow` for columns the attached schema declares `{ type: 'boolean' }`. `null` and any non-0/1 value passes through unchanged. The write path was already accepting both `true`/`false` and `0`/`1` and is unchanged. **Behaviour change:** callers that compared boolean columns against `0` / `1` strictly (`row.col === 1`) need to switch to `=== true` / `=== false`. Code using `Boolean(row.col)` or loose equality (`== true`) is unaffected. The coercion only activates when a schema is attached at construction; callers using `new SqliteConnector(':memory:')` (no schema) still see raw 0 / 1 INTEGER reads.
+
 ## v1.1.0
 
 ## v1.0.0

--- a/packages/sqlite-connector/README.md
+++ b/packages/sqlite-connector/README.md
@@ -63,6 +63,19 @@ const connector = new SqliteConnector(':memory:', { schema });
 
 The `extras: { schema }` arg is purely a type-level decoration — the runtime contract is unchanged, and existing constructor call sites without a schema keep working.
 
+### Materialising tables with `ensureSchema()`
+
+Once a schema is attached, `connector.ensureSchema()` walks every declared table and creates any that don't already exist. It's idempotent — call it on every app boot:
+
+```ts
+const connector = new SqliteConnector('./data/app.sqlite', { schema });
+const { created, existing } = await connector.ensureSchema();
+// first boot:  { created: ['users', 'posts', ...], existing: [] }
+// later boots: { created: [], existing: ['users', 'posts', ...] }
+```
+
+Calling `ensureSchema()` without a schema throws — pass `{ schema }` at construction.
+
 ## Wiring a Model
 
 ```ts
@@ -109,6 +122,30 @@ All identifiers are quoted with `"…"`. Identifiers are validated against `^[A-
 - `boolean` → `1` / `0`.
 
 This lets you pass JS-native values directly through Model.
+
+### Boolean read-side coercion
+
+SQLite has no native boolean kind; `better-sqlite3` returns 0 / 1 as `INTEGER` for any column declared `boolean`. When a schema is attached to the connector, columns declared `{ type: 'boolean' }` are coerced back to `true` / `false` on every read — strict identity (`=== true` / `=== false`) works without a `Boolean(...)` wrapper.
+
+```ts
+const schema = defineSchema({
+  users: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      isAdmin: { type: 'boolean', null: false },
+    },
+  },
+});
+const c = new SqliteConnector(':memory:', { schema });
+await c.ensureSchema();
+await c.batchInsert('users', { id: 1 } as any, [{ isAdmin: true }]);
+const [row] = await c.query({ tableName: 'users' });
+row.isAdmin === true; // ← was `row.isAdmin === 1` before
+```
+
+The coercion only kicks in when an actual schema is attached. Existing call sites that use `new SqliteConnector(':memory:')` with no schema (or run against pre-existing tables that were never declared through `defineSchema`) keep reading raw `0` / `1` INTEGER, so older code that compared columns with `=== 1` continues to compile and work — only the new schema-driven path opts into strict booleans.
+
+`null` and any non-`0`/`1` integer value passes through unchanged.
 
 ### `execute(query, bindings)`
 

--- a/packages/sqlite-connector/package.json
+++ b/packages/sqlite-connector/package.json
@@ -14,8 +14,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "!dist/**/__tests__",
-    "!dist/**/*.map"
+    "!dist/**/__tests__"
   ],
   "repository": {
     "type": "git",

--- a/packages/sqlite-connector/src/SqliteConnector.ts
+++ b/packages/sqlite-connector/src/SqliteConnector.ts
@@ -92,6 +92,7 @@ export class SqliteConnector<S extends DatabaseSchema<any> | undefined = undefin
   db: DatabaseType;
   private inTransaction = false;
   private jsonColumns = new Map<string, Set<string>>();
+  private booleanColumns = new Map<string, Set<string>>();
   private tableDefinitions = new Map<string, TableDefinition>();
   private foreignKeys = new Map<string, ForeignKeyEntry[]>();
   private checkConstraints = new Map<string, CheckEntry[]>();
@@ -110,6 +111,10 @@ export class SqliteConnector<S extends DatabaseSchema<any> | undefined = undefin
     return this.jsonColumns.get(tableName);
   }
 
+  private booleanColumnsFor(tableName: string): Set<string> | undefined {
+    return this.booleanColumns.get(tableName);
+  }
+
   private serializeRow<T extends Dict<any>>(tableName: string, row: T): T {
     const jsonCols = this.jsonColumnsFor(tableName);
     if (!jsonCols || jsonCols.size === 0) return row;
@@ -125,16 +130,36 @@ export class SqliteConnector<S extends DatabaseSchema<any> | undefined = undefin
 
   private hydrateRow<T extends Dict<any>>(tableName: string, row: T): T {
     const jsonCols = this.jsonColumnsFor(tableName);
-    if (!jsonCols || jsonCols.size === 0) return row;
+    // Boolean coercion only kicks in when an actual schema is attached on the
+    // connector. Without a schema we cannot reliably tell whether the source
+    // application means a column to hold true/false versus the 0/1 INTEGER
+    // sentinels SQLite uses for arbitrary integer columns — so we leave raw
+    // 0/1 values alone in that case.
+    const boolCols = this.schema ? this.booleanColumnsFor(tableName) : undefined;
+    const hasJson = jsonCols && jsonCols.size > 0;
+    const hasBool = boolCols && boolCols.size > 0;
+    if (!hasJson && !hasBool) return row;
     const out: Dict<any> = { ...row };
-    for (const col of jsonCols) {
-      const v = out[col];
-      if (typeof v === 'string') {
-        try {
-          out[col] = JSON.parse(v);
-        } catch {
-          // Leave non-JSON strings alone — tolerates pre-existing rows.
+    if (hasJson) {
+      for (const col of jsonCols as Set<string>) {
+        const v = out[col];
+        if (typeof v === 'string') {
+          try {
+            out[col] = JSON.parse(v);
+          } catch {
+            // Leave non-JSON strings alone — tolerates pre-existing rows.
+          }
         }
+      }
+    }
+    if (hasBool) {
+      // SQLite has no native boolean — values come back as 0/1 INTEGER. When
+      // the attached schema declares a column as `boolean`, coerce on read so
+      // `row.col === true` / `=== false` work strictly. null / undefined and
+      // non-0/1 values are passed through unchanged.
+      for (const col of boolCols as Set<string>) {
+        const v = out[col];
+        if (v === 0 || v === 1) out[col] = v === 1;
       }
     }
     return out as T;
@@ -780,6 +805,8 @@ export class SqliteConnector<S extends DatabaseSchema<any> | undefined = undefin
     this.tableDefinitions.set(tableName, def);
     const jsonCols = new Set(def.columns.filter((c) => c.type === 'json').map((c) => c.name));
     if (jsonCols.size > 0) this.jsonColumns.set(tableName, jsonCols);
+    const boolCols = new Set(def.columns.filter((c) => c.type === 'boolean').map((c) => c.name));
+    if (boolCols.size > 0) this.booleanColumns.set(tableName, boolCols);
     if (await this.hasTable(tableName)) return;
     this.runStatement(this.buildCreateTableSql(tableName, def, [], []));
     for (const idx of def.indexes) await this.createIndex(tableName, idx);
@@ -834,6 +861,7 @@ export class SqliteConnector<S extends DatabaseSchema<any> | undefined = undefin
   async dropTable(tableName: string): Promise<void> {
     this.runStatement(`DROP TABLE IF EXISTS ${quoteIdent(tableName)}`);
     this.jsonColumns.delete(tableName);
+    this.booleanColumns.delete(tableName);
     this.tableDefinitions.delete(tableName);
     this.foreignKeys.delete(tableName);
     this.checkConstraints.delete(tableName);
@@ -852,6 +880,7 @@ export class SqliteConnector<S extends DatabaseSchema<any> | undefined = undefin
         const def = definitionFromOp(op.name, op.type, op.options);
         this.runStatement(`ALTER TABLE ${quoteIdent(tableName)} ADD COLUMN ${this.columnDdl(def)}`);
         if (op.type === 'json') this.markJsonColumn(tableName, op.name);
+        if (op.type === 'boolean') this.markBooleanColumn(tableName, op.name);
         this.applyToTrackedDefinition(tableName, [op]);
         return;
       }
@@ -860,6 +889,7 @@ export class SqliteConnector<S extends DatabaseSchema<any> | undefined = undefin
           `ALTER TABLE ${quoteIdent(tableName)} DROP COLUMN ${quoteIdent(op.name)}`,
         );
         this.unmarkJsonColumn(tableName, op.name);
+        this.unmarkBooleanColumn(tableName, op.name);
         this.applyToTrackedDefinition(tableName, [op]);
         return;
       case 'renameColumn':
@@ -867,6 +897,7 @@ export class SqliteConnector<S extends DatabaseSchema<any> | undefined = undefin
           `ALTER TABLE ${quoteIdent(tableName)} RENAME COLUMN ${quoteIdent(op.from)} TO ${quoteIdent(op.to)}`,
         );
         this.renameJsonColumn(tableName, op.from, op.to);
+        this.renameBooleanColumn(tableName, op.from, op.to);
         this.applyToTrackedDefinition(tableName, [op]);
         return;
       case 'addIndex':
@@ -994,6 +1025,8 @@ export class SqliteConnector<S extends DatabaseSchema<any> | undefined = undefin
     this.foreignKeys.set(tableName, nextFks);
     this.checkConstraints.set(tableName, nextChecks);
     if (op.op === 'changeColumn' && op.type === 'json') this.markJsonColumn(tableName, op.name);
+    if (op.op === 'changeColumn' && op.type === 'boolean')
+      this.markBooleanColumn(tableName, op.name);
   }
 
   private applyToTrackedDefinition(tableName: string, ops: AlterTableOp[]): void {
@@ -1020,6 +1053,29 @@ export class SqliteConnector<S extends DatabaseSchema<any> | undefined = undefin
 
   private renameJsonColumn(tableName: string, from: string, to: string): void {
     const set = this.jsonColumns.get(tableName);
+    if (!set?.has(from)) return;
+    set.delete(from);
+    set.add(to);
+  }
+
+  private markBooleanColumn(tableName: string, col: string): void {
+    let set = this.booleanColumns.get(tableName);
+    if (!set) {
+      set = new Set();
+      this.booleanColumns.set(tableName, set);
+    }
+    set.add(col);
+  }
+
+  private unmarkBooleanColumn(tableName: string, col: string): void {
+    const set = this.booleanColumns.get(tableName);
+    if (!set) return;
+    set.delete(col);
+    if (set.size === 0) this.booleanColumns.delete(tableName);
+  }
+
+  private renameBooleanColumn(tableName: string, from: string, to: string): void {
+    const set = this.booleanColumns.get(tableName);
     if (!set?.has(from)) return;
     set.delete(from);
     set.add(to);

--- a/packages/sqlite-connector/src/SqliteConnector.ts
+++ b/packages/sqlite-connector/src/SqliteConnector.ts
@@ -785,6 +785,52 @@ export class SqliteConnector<S extends DatabaseSchema<any> | undefined = undefin
     for (const idx of def.indexes) await this.createIndex(tableName, idx);
   }
 
+  /**
+   * Materialise every table declared in the attached `schema` idempotently.
+   * Iterates `schema.tableDefinitions`, skipping tables that already exist
+   * and dispatching unknown tables through this connector's `createTable`
+   * so SQLite-specific column-type rendering applies.
+   */
+  async ensureSchema(): Promise<{ created: string[]; existing: string[] }> {
+    if (!this.schema) {
+      throw new Error(
+        'SqliteConnector.ensureSchema(): no schema is attached. Pass `{ schema }` at construction.',
+      );
+    }
+    const created: string[] = [];
+    const existing: string[] = [];
+    const tableDefinitions = this.schema.tableDefinitions as Record<string, TableDefinition>;
+    for (const tableName of Object.keys(tableDefinitions)) {
+      if (await this.hasTable(tableName)) {
+        existing.push(tableName);
+        continue;
+      }
+      const def = tableDefinitions[tableName];
+      await this.createTable(tableName, (t) => {
+        for (const col of def.columns) {
+          const options: ColumnOptions = {
+            null: col.nullable,
+            primary: col.primary,
+            unique: col.unique,
+            autoIncrement: col.autoIncrement,
+          };
+          if (col.default !== undefined) options.default = col.default;
+          if (col.limit !== undefined) options.limit = col.limit;
+          if (col.precision !== undefined) options.precision = col.precision;
+          if (col.scale !== undefined) options.scale = col.scale;
+          t.column(col.name, col.type, options);
+        }
+        for (const idx of def.indexes) {
+          const indexOptions: { name?: string; unique?: boolean } = { unique: idx.unique };
+          if (idx.name !== undefined) indexOptions.name = idx.name;
+          t.index(idx.columns, indexOptions);
+        }
+      });
+      created.push(tableName);
+    }
+    return { created, existing };
+  }
+
   async dropTable(tableName: string): Promise<void> {
     this.runStatement(`DROP TABLE IF EXISTS ${quoteIdent(tableName)}`);
     this.jsonColumns.delete(tableName);

--- a/packages/sqlite-connector/src/__tests__/booleanCoercion.spec.ts
+++ b/packages/sqlite-connector/src/__tests__/booleanCoercion.spec.ts
@@ -1,0 +1,107 @@
+import { defineSchema } from '@next-model/core';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { SqliteConnector } from '../index.js';
+
+const schema = defineSchema({
+  toggles: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      isDefault: { type: 'boolean', null: false },
+      nullableFlag: { type: 'boolean', null: true },
+      label: { type: 'string', null: false },
+    },
+  },
+});
+
+describe('SqliteConnector boolean coercion (read path)', () => {
+  let connector: SqliteConnector<typeof schema> | SqliteConnector<undefined>;
+
+  afterEach(() => {
+    connector?.destroy();
+  });
+
+  it('coerces 0/1 → false/true strictly when a schema is attached', async () => {
+    const c = new SqliteConnector(':memory:', { schema });
+    connector = c;
+    await c.ensureSchema();
+    await c.batchInsert('toggles', { id: 1 } as any, [
+      { isDefault: true, nullableFlag: false, label: 'a' },
+      { isDefault: false, nullableFlag: true, label: 'b' },
+    ]);
+    const rows = await c.query({ tableName: 'toggles' });
+    expect(rows).toHaveLength(2);
+    const a = rows.find((r) => r.label === 'a')!;
+    const b = rows.find((r) => r.label === 'b')!;
+    expect(a.isDefault).toBe(true);
+    expect(a.nullableFlag).toBe(false);
+    expect(b.isDefault).toBe(false);
+    expect(b.nullableFlag).toBe(true);
+    // Strict identity, not just truthy:
+    expect(a.isDefault === true).toBe(true);
+    expect(b.isDefault === false).toBe(true);
+  });
+
+  it('preserves null for nullable boolean columns', async () => {
+    const c = new SqliteConnector(':memory:', { schema });
+    connector = c;
+    await c.ensureSchema();
+    await c.batchInsert('toggles', { id: 1 } as any, [
+      { isDefault: true, nullableFlag: null, label: 'a' },
+    ]);
+    const [row] = await c.query({ tableName: 'toggles' });
+    expect(row.isDefault).toBe(true);
+    expect(row.nullableFlag).toBeNull();
+  });
+
+  it('round-trips boolean updates strictly', async () => {
+    const c = new SqliteConnector(':memory:', { schema });
+    connector = c;
+    await c.ensureSchema();
+    await c.batchInsert('toggles', { id: 1 } as any, [
+      { isDefault: true, nullableFlag: false, label: 'a' },
+    ]);
+    const [updated] = await c.updateAll({ tableName: 'toggles', filter: { label: 'a' } as any }, {
+      isDefault: false,
+      nullableFlag: true,
+    } as any);
+    expect(updated.isDefault).toBe(false);
+    expect(updated.nullableFlag).toBe(true);
+  });
+
+  it('leaves raw 0/1 untouched when no schema is attached', async () => {
+    // Without a schema, the connector cannot tell whether a 0/1 integer
+    // column was meant as a boolean. Existing callers may rely on raw
+    // numeric reads — preserve that behaviour.
+    const c = new SqliteConnector(':memory:');
+    connector = c;
+    await c.createTable('legacy_toggles', (t) => {
+      t.integer('id', { primary: true, autoIncrement: true });
+      t.boolean('flag');
+    });
+    await c.batchInsert('legacy_toggles', { id: 1 } as any, [{ flag: true }, { flag: false }]);
+    const rows = await c.query({ tableName: 'legacy_toggles' });
+    expect(rows.map((r) => r.flag).sort()).toEqual([0, 1]);
+  });
+
+  it('does not touch non-boolean columns even when both kinds coexist', async () => {
+    const mixedSchema = defineSchema({
+      mixed: {
+        columns: {
+          id: { type: 'integer', primary: true, autoIncrement: true },
+          flag: { type: 'boolean', null: false },
+          count: { type: 'integer', null: false },
+        },
+      },
+    });
+    const c = new SqliteConnector(':memory:', { schema: mixedSchema });
+    connector = c as unknown as typeof connector;
+    await c.ensureSchema();
+    await c.batchInsert('mixed', { id: 1 } as any, [{ flag: true, count: 1 }]);
+    const [row] = await c.query({ tableName: 'mixed' });
+    // count is integer, must stay numeric even though 1 looks like a truthy flag.
+    expect(row.flag).toBe(true);
+    expect(row.count).toBe(1);
+    expect(typeof row.count).toBe('number');
+  });
+});

--- a/packages/sqlite-connector/src/__tests__/ensureSchema.spec.ts
+++ b/packages/sqlite-connector/src/__tests__/ensureSchema.spec.ts
@@ -1,0 +1,93 @@
+import { defineSchema } from '@next-model/core';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { SqliteConnector } from '../index.js';
+
+const schema = defineSchema({
+  users: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      email: { type: 'string', null: false, unique: true, limit: 320 },
+      name: { type: 'string', null: true },
+      createdAt: { type: 'timestamp', default: 'currentTimestamp', null: false },
+    },
+    indexes: [{ columns: ['email'], unique: true, name: 'idx_users_email' }],
+  },
+  posts: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      userId: { type: 'integer', null: false },
+      title: { type: 'string', null: false },
+      body: { type: 'text', null: true },
+    },
+    indexes: [{ columns: ['userId'], unique: false }],
+  },
+  tags: {
+    columns: {
+      slug: { type: 'string', primary: true },
+    },
+  },
+});
+
+describe('SqliteConnector#ensureSchema', () => {
+  let connector: SqliteConnector<typeof schema>;
+
+  afterEach(() => {
+    connector?.destroy();
+  });
+
+  it('creates every table declared on the attached schema', async () => {
+    connector = new SqliteConnector(':memory:', { schema });
+    const result = await connector.ensureSchema();
+    expect(result.created.sort()).toEqual(['posts', 'tags', 'users']);
+    expect(result.existing).toEqual([]);
+    expect(await connector.hasTable('users')).toBe(true);
+    expect(await connector.hasTable('posts')).toBe(true);
+    expect(await connector.hasTable('tags')).toBe(true);
+  });
+
+  it('is idempotent on a second call', async () => {
+    connector = new SqliteConnector(':memory:', { schema });
+    await connector.ensureSchema();
+    const result = await connector.ensureSchema();
+    expect(result.created).toEqual([]);
+    expect(result.existing.sort()).toEqual(['posts', 'tags', 'users']);
+  });
+
+  it('only creates missing tables when some already exist', async () => {
+    connector = new SqliteConnector(':memory:', { schema });
+    await connector.createTable('users', (t) => {
+      t.integer('id', { primary: true, autoIncrement: true });
+    });
+    const result = await connector.ensureSchema();
+    expect(result.existing).toEqual(['users']);
+    expect(result.created.sort()).toEqual(['posts', 'tags']);
+  });
+
+  it('produces a usable table — round-trip insert + select', async () => {
+    connector = new SqliteConnector(':memory:', { schema });
+    await connector.ensureSchema();
+    const [inserted] = await connector.batchInsert('users', { id: 1 } as any, [
+      { email: 'a@example.com', name: 'Alice' },
+    ]);
+    expect(inserted.id).toBeDefined();
+    expect(inserted.email).toBe('a@example.com');
+    const rows = await connector.query({ tableName: 'users' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].email).toBe('a@example.com');
+  });
+
+  it('honours the unique index from the schema', async () => {
+    connector = new SqliteConnector(':memory:', { schema });
+    await connector.ensureSchema();
+    await connector.batchInsert('users', { id: 1 } as any, [{ email: 'dup@example.com' }]);
+    await expect(
+      connector.batchInsert('users', { id: 1 } as any, [{ email: 'dup@example.com' }]),
+    ).rejects.toThrow();
+  });
+
+  it('throws when no schema is attached', async () => {
+    connector = new SqliteConnector(':memory:') as SqliteConnector<typeof schema>;
+    await expect(connector.ensureSchema()).rejects.toThrow(/no schema is attached/);
+  });
+});


### PR DESCRIPTION
## Motivation

After constructing a connector with a schema attached:

```ts
const connector = new SqliteConnector('/path/db.sqlite', { schema });
```

…the file is empty until the caller manually iterates `schema.tableDefinitions` and translates each column / index back into the `createTable` builder DSL. That boilerplate ends up being repeated by every consumer, and there's no good reason for it — the schema already encodes everything `createTable` needs.

Discovered while integrating into an Electron + React desktop app: every entrypoint (main process, renderer, test harness) needed its own helper that did the same `Object.keys(schema.tableDefinitions).forEach(...)` walk.

## What this PR adds

```ts
interface Connector {
  ensureSchema?(): Promise<{ created: string[]; existing: string[] }>;
}
```

- Walks `this.schema.tableDefinitions`
- For each table: `hasTable(name)` → push to `existing`; otherwise call `createTable(name, builder)` with the column + index definitions from the schema, push to `created`
- Throws a clear error when no schema is attached
- Returns the summary

Implemented on:
- `MemoryConnector` (the base case) — `LocalStorageConnector` inherits it
- `SqliteConnector` — direct implementation

The method is **optional** on the `Connector` interface, mirroring `reflectSchema` / `queryWithJoins` / `queryScoped`. That keeps the change strictly additive: every other connector in the workspace (knex / pg / mysql / mongo / redis / aurora / recording / null / schema-collector) compiles unchanged. They can opt in incrementally in follow-up PRs.

Reuses each connector's existing `createTable(name, builder)` path, so SQLite-specific column rendering (VARCHAR(n), NUMERIC(p,s), JSON-as-TEXT, etc.) is preserved automatically — no re-implementation of the column-builder DSL.

## Sourcemaps

`@next-model/core`, `@next-model/sqlite-connector`, `@next-model/local-storage-connector`, and `@next-model/react` now publish `dist/**/*.map` alongside `dist/**/*.js`. The build already emits source maps (the shared `tsconfig.base.json` has `sourceMap: true`); the four `package.json` `files` fields were explicitly excluding `*.map`, which caused downstream Vite consumers to log `Failed to load source map ... ENOENT`. Removing the exclusion costs ~once per package and unbreaks debugging.

Other packages (knex / pg / mysql / mongo / redis / aurora / migrations / migrations-generator / arktype / zod / typebox / express-rest-api / graphql-api / nextjs-api / valkey) have the same exclusion and will follow in a separate PR.

## Tests

- `packages/core/src/__tests__/ensureSchema.spec.ts` — 4 cases (create-all, idempotent, partial-create, missing-schema error)
- `packages/sqlite-connector/src/__tests__/ensureSchema.spec.ts` — 6 cases including a real insert + select round-trip and a unique-index conflict
- `packages/local-storage-connector/src/__tests__/ensureSchema.spec.ts` — 4 cases including rehydration from a fresh connector pointed at the same storage

## CI

`pnpm lint && pnpm typecheck && pnpm test` all pass. Lint surfaces one pre-existing `noUnusedImports` warning in `Model.spec.ts` that's untouched by this branch.

---

## Subsequent commits in this PR

Additional fixes layered on top of the `ensureSchema()` feature, surfaced by the same Electron migration. Each one is a small, isolated improvement; each lives in its own commit so the review history stays clean.

- **`fix(core): compose mixed-object filters correctly`** (`81c5650`). `filterBy({ workspaceId: 1, $null: 'archivedAt' })` previously dropped the `workspaceId` predicate because every connector's `compileFilter` short-circuits on the first `$`-prefixed key. `normalizeFilterShape` now lifts every top-level operator into its own AND-piece when the filter object also contains sibling equality or other operators. 8 new tests in `filterShape.spec.ts`.
- **`test(core): pin nested $in / $notIn filter syntax equivalence`** (`d4a88f2`). Adds explicit regression tests for the conventional `filterBy({ col: { $in: [...] } })` shape (rewritten to the top-level form by the normaliser) plus a mixed case that combines with the previous commit. No production code change.
- **`feat(sqlite-connector): coerce boolean columns on read when schema is attached`** (`405be71`). SQLite returns 0 / 1 INTEGER for `boolean` columns; `row.col === true` would silently fail. The connector now mirrors its existing JSON-column tracking and coerces 0 / 1 → false / true inside `hydrateRow` for columns the attached schema declares `boolean`. Only activates when a schema is attached. Behaviour change for strict `=== 1` / `=== 0` callers — called out in the changelog. 5 new tests in `booleanCoercion.spec.ts`.
- **`fix(core): install property getters from schema columns, not insert-time keys`** (`ffc0c0a`). The Model instance constructor only installed accessors for keys present in `persistentProps` at construction. Columns omitted at insert (typically nullable timestamps like `archivedAt`) never got a getter, so `instance.update({ archivedAt: new Date() })` set the value but `instance.archivedAt` still read `undefined`. The factory now pins `static schemaColumnNames` from the resolved `tableDefinition`; the constructor installs accessors for every declared column. 5 new tests in `schemaPropertyGetters.spec.ts`.
- **`feat(core): enrich ValidationError.message with offending field details`** (`32b97b6`). `ValidationError.message` was the bare string `"Validation failed"` — `expect(p).rejects.toThrow(/name/)` couldn't work without inspecting the rejected instance. The message is now synthesised from the structured `.errors` payload (`"Validation failed: name: cannot be blank; email: cannot be blank"`); the single-argument call shape `new ValidationError(errors)` is also accepted. 5 new tests in `validators.spec.ts`.

Plus two docs commits:

- **`docs(readme): document ensureSchema, ValidationError, filter ergonomics, sqlite boolean coercion`** (`19f8b60`). Top-level + core + sqlite-connector + local-storage-connector + react READMEs.
- **`docs(changelog): record ensureSchema + filter/boolean/getter/validation improvements`** (`ad6e09a`). vNext entries on every affected `HISTORY.md`.

`pnpm lint && pnpm typecheck && pnpm test` is green after every commit. `pnpm --filter @next-model/sqlite-connector test` (not in the root `ci` script) is also green.
