### PR TITLE
refactor(core): Model factory return type emits cleanly to .d.ts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,12 @@ jobs:
       - run: pnpm -r --filter './packages/*' build
       - run: pnpm typecheck
       - run: pnpm typecheck:demos
+      # Acceptance test: a downstream package that re-exports
+      # `class Foo extends Model({...}) {}` must successfully emit `.d.ts`.
+      # Builds the `examples/declaration-emit` fixture with
+      # `tsc --emitDeclarationOnly --declaration true`; CI fails if TS can't
+      # serialise the inferred Model factory return type.
+      - run: pnpm -r --filter './examples/*' run build
       - run: pnpm test:release
 
   test-core:

--- a/examples/declaration-emit/package.json
+++ b/examples/declaration-emit/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@next-model-examples/declaration-emit",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Acceptance test: downstream package re-exports a Model class and emits .d.ts cleanly.",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "pnpm clean && tsc --emitDeclarationOnly --declaration",
+    "test": "pnpm build"
+  },
+  "dependencies": {
+    "@next-model/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/declaration-emit/src/index.ts
+++ b/examples/declaration-emit/src/index.ts
@@ -1,0 +1,74 @@
+/**
+ * Acceptance test: downstream packages must be able to re-export
+ * a class extending `Model({...})` and emit clean `.d.ts` declarations.
+ *
+ * Before the fix the build below would fail with:
+ *   TS7056: The inferred type of this node exceeds the maximum length the
+ *           compiler will serialize. An explicit type annotation is needed.
+ *   TS2742 / TS2883: The inferred type of 'X' cannot be named without a
+ *           reference to '@next-model/core/...'. This is likely not portable.
+ *
+ * Build this fixture with `tsc --emitDeclarationOnly --declaration true` and
+ * make sure it succeeds.
+ */
+import { defineSchema, MemoryConnector, Model } from '@next-model/core';
+
+const schema = defineSchema({
+  users: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      name: { type: 'string' },
+      age: { type: 'integer', null: true },
+      role: { type: 'string' },
+      createdAt: { type: 'datetime' },
+      updatedAt: { type: 'datetime' },
+    },
+    associations: {
+      posts: { hasMany: 'posts', foreignKey: 'userId' },
+    },
+  },
+  posts: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      title: { type: 'string' },
+      body: { type: 'text', null: true },
+      userId: { type: 'integer' },
+      createdAt: { type: 'datetime' },
+      updatedAt: { type: 'datetime' },
+    },
+    associations: {
+      author: { belongsTo: 'users', foreignKey: 'userId' },
+    },
+  },
+});
+
+export const connector = new MemoryConnector({ storage: {} }, { schema });
+
+/**
+ * Downstream re-export — extends a Model class produced by the factory and is
+ * itself exported. This is the shape that previously broke `.d.ts` emission
+ * because TS could not name the internal `CollectionQuery` / `InstanceQuery`
+ * / `ColumnQuery` / `ScalarQuery` types referenced by the factory's
+ * inferred return type.
+ */
+export class User extends Model({
+  connector,
+  tableName: 'users',
+  scopes: {
+    adults: { $gte: { age: 18 } } as const,
+  },
+  enums: {
+    role: ['admin', 'user'] as const,
+  },
+}) {
+  /** Domain method on the subclass to make sure subclass surface still works. */
+  greet(): string {
+    const attrs = this.attributes as { name: string };
+    return `hi, I'm ${attrs.name}`;
+  }
+}
+
+export class Post extends Model({
+  connector,
+  tableName: 'posts',
+}) {}

--- a/examples/declaration-emit/tsconfig.json
+++ b/examples/declaration-emit/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false,
+    "composite": false,
+    "types": []
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -8,7 +8,6 @@ import {
   type Storage,
 } from '../index.js';
 import { CollectionQuery } from '../query/CollectionQuery.js';
-import { InstanceQuery } from '../query/InstanceQuery.js';
 import { context, it } from './index.js';
 
 const fooSchema = defineSchema({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,18 @@ export * from './FilterEngine.js';
 export * from './MemoryConnector.js';
 export * from './Model.js';
 export { baseQueryScoped } from './query/baseQueryScoped.js';
+// Re-export the chainable query classes so downstream packages that extend a
+// Model class can serialise the inferred return type of `Model({...})` into
+// `.d.ts`. Without these, `tsc --emitDeclarationOnly` errors with TS2883
+// ("inferred type cannot be named without a reference to `CollectionQuery`
+// from '../node_modules/@next-model/core/dist/query/...'"). Re-exporting the
+// classes via the package root means TS resolves them by name and the
+// declaration emit succeeds.
+export { CollectionQuery } from './query/CollectionQuery.js';
+export { ColumnQuery } from './query/ColumnQuery.js';
+export { InstanceQuery } from './query/InstanceQuery.js';
+export type { ParentRef, QueryState, TerminalKind } from './query/QueryState.js';
+export { ScalarQuery } from './query/ScalarQuery.js';
 export * from './schema.js';
 export * from './typedSchema.js';
 export * from './types.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,16 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)
 
+  examples/declaration-emit:
+    dependencies:
+      '@next-model/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   packages/arktype:
     devDependencies:
       '@next-model/core':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,3 +23,4 @@ packages:
   - "demos/node/client/*"
   - "demos/react/*"
   - "demos/nextjs/*"
+  - "examples/*"


### PR DESCRIPTION
## Summary

Downstream packages that re-export a class extending `Model({...})` — e.g.
`export class User extends Model({ connector, tableName: 'users' }) {}` —
could not emit `.d.ts` declarations. `tsc --emitDeclarationOnly --declaration true`
failed with TS2883:

```
error TS2883: The inferred type of 'User' cannot be named without a reference
to 'CollectionQuery' from '../node_modules/@next-model/core/dist/query/CollectionQuery.js'.
This is likely not portable. A type annotation is necessary.
```

The Model factory's return type references `CollectionQuery`, `InstanceQuery`,
`ColumnQuery`, and `ScalarQuery`, but those classes were only reachable
through internal deep paths under `query/`. When TS emits a declaration for
a downstream subclass, it needs a *public* name for every type the
intersection references. With no public name, it falls back to TS2883.

## Approach

Approach 2 (type-assertion / re-export at the boundary) from the spec —
strictly the minimal-surface variant. Approach 1 (reshaping the factory
to return a flat `Model<TSchema, TName>` interface) would have churned
>1500 lines of `Model.ts` for the same outcome.

The fix is a single export block in `packages/core/src/index.ts`:

```ts
export { CollectionQuery } from './query/CollectionQuery.js';
export { ColumnQuery } from './query/ColumnQuery.js';
export { InstanceQuery } from './query/InstanceQuery.js';
export type { ParentRef, QueryState, TerminalKind } from './query/QueryState.js';
export { ScalarQuery } from './query/ScalarQuery.js';
```

The classes were already concrete and importable through their internal
paths — this just makes them discoverable via the package root, which is
what TS needs to write them into a downstream `.d.ts`.

## Acceptance test

New workspace package `examples/declaration-emit/` whose `build` script
runs `tsc --emitDeclarationOnly --declaration true` against a file that
re-exports a `Model({...})`-derived class. Verified to fail on
`v1.1.2` and pass on this branch.

CI gates it via the existing `validate` job: `pnpm -r --filter './examples/*' run build`.

## Verification

- `pnpm run ci` green locally — lint, typecheck, 6217 tests passing
  across every package.
- `pnpm -r --filter './examples/*' run build` succeeds.
- Without the export fix the example fixture's build fails with 8 × TS2883.

## Breaking changes

None. The change is strictly additive — four classes and three types
that were already accessible via deep imports are now also accessible
from the package root. Any downstream code that previously imported
`CollectionQuery` from `@next-model/core/dist/query/CollectionQuery.js`
keeps working; new code can import from `@next-model/core` directly.

## Test plan

- [x] `examples/declaration-emit` builds with `tsc --emitDeclarationOnly --declaration true`
- [x] `pnpm run ci` stays green (6217 tests, lint, typecheck)
- [x] CI workflow runs the new fixture build in `validate`