### PR TITLE
feat(ergonomics + docs): withOrder/reorder, Model.Instance, schema-inferred timestamps, doc fills

### DIFF
--- a/packages/core/HISTORY.md
+++ b/packages/core/HISTORY.md
@@ -2,6 +2,11 @@
 
 ## vNext
 
+### Added
+
+- `withOrder(order)` is the new "replace ORDER BY" chainable on `CollectionQuery` and the Model static surface — semantically identical to the old `reorder()` but the name no longer shadows user-facing static methods on subclasses (e.g. `Item.reorder([...])` for "reorder items by sortOrder"). `reorder()` still works as a deprecated alias and emits a one-shot `console.warn` per process.
+- `Model.Instance` is a phantom static type alias on every Model factory output (`typeof MyModel.Instance`). The runtime value is always `undefined`; TypeScript consults the declared shape `InstanceType<M> & Assoc & PersistentProps & Readonly<Keys…>` so subclass static methods returning hydrated records can use `typeof MyModel.Instance` as their return / parameter type without spelling out `Awaited<ReturnType<typeof MyModel.create>>` or losing the column-getter intersection.
+
 ### Changed
 
 - **Breaking (in-memory only)**: `MemoryConnector` and its subclasses no longer compile `$raw.$query` / `execute(query, ...)` strings at runtime through dynamic code evaluation. The shipped `dist/*.js` bundles are now free of every dynamic-code-evaluation call site, so `@next-model/core` can be consumed under a strict `Content-Security-Policy: script-src 'self'` (the default in Electron renderers and most security-sensitive web apps). It also unblocks tree-shaking and source-map fidelity. SQL connectors (Knex / Postgres / Sqlite / Mysql / MariaDB / DataApi) are unaffected — they treat `$raw.$query` as a SQL fragment, not JS source. Migration: pass a function instead of a string source.
@@ -9,6 +14,11 @@
   - `MemoryConnector.execute('(storage) => storage.users', [])` → `MemoryConnector.execute((storage) => storage.users, [])`.
   - Passing a string to a JS-evaluating connector now throws a `FilterError` / `UnsupportedOperationError` with a migration hint pointing at the function form.
 - A new acceptance test (`.github/scripts/no-eval-in-dist.test.mjs`, wired into `pnpm test:release`) scans every `packages/*/dist/**/*.js` and fails CI if any future change reintroduces a dynamic-evaluation call site.
+- The Model factory's `timestamps:` option is now inferred from the schema's column declarations when the caller doesn't pass it explicitly. A table with both `createdAt` and `updatedAt` columns keeps the historical default (enable both); only-`createdAt` behaves as `{ updatedAt: false }`; only-`updatedAt` behaves as `{ createdAt: false }`; neither behaves as `timestamps: false`. **Behaviour change in the niche where it bites** — `Model({ tableName: 'sessions', connector })` against a `sessions` table that didn't declare `createdAt` / `updatedAt` previously failed inserts with `SqliteError: table sessions has no column named createdAt`; it now succeeds. Explicit `timestamps:` (any value) always wins. Two internal test fixtures (`Model.spec` foo, `persistenceErgonomics.spec` posts) gained `createdAt` / `updatedAt` columns to preserve their existing semantics under the new schema-aware default.
+
+### Docs
+
+- README sections added / expanded across `@next-model/core` + `@next-model/sqlite-connector`: Electron integration walkthrough (preload + `contextIsolation: false`, Vite renderer config, renderer top-level-await bootstrap chain, `window.require('fs')` gotcha), `defineSchema` vs `defineTable` distinction callout, `Object.keys(schema.tableDefinitions)` iteration snippet, validators-are-a-flat-array callout, "Testing with Models" subsection (typed `makeX(props?)` factory helper pattern instead of `as any` in fixtures), refreshed `orderBy` / `withOrder` section, schema-aware Timestamps inference notes.
 
 ## v1.1.2
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -16,7 +16,7 @@ A typed, promise-based ORM for TypeScript. Declare models with a factory, chain 
 - [Deleting](#deleting)
 - [Querying](#querying)
   - [filterBy / orFilterBy](#filterby--orfilterby)
-  - [orderBy / reorder / reverse / unordered](#orderby--reorder--reverse--unordered)
+  - [orderBy / withOrder / reverse / unordered](#orderby--withorder--reverse--unordered)
   - [limitBy / skipBy / unlimited / unskipped](#limitby--skipby--unlimited--unskipped)
   - [unfiltered / unscoped](#unfiltered--unscoped)
   - [Default scope](#default-scope)
@@ -56,6 +56,8 @@ Models are defined via the `Model({...})` factory, which returns a class you can
 ### Schema-driven props
 
 Instead of writing an `init` callback to give TypeScript the row shape, declare a full database schema with `defineSchema(...)` and attach it to the connector. Each Model picks a table off the connector's schema by `tableName` — TypeScript infers the prop shape, `keys`, and `init` from the column map at the call site.
+
+> **`defineSchema` vs `defineTable`.** These are two different APIs and the difference trips up first-time users. **`defineSchema(...)`** takes a record of plain `{ columns, associations? }` literals (column objects keyed by name) — the declarative shape shown below; this is what you want for typed Models. **`defineTable(name, callback)`** is an imperative builder used by `@next-model/migrations` (`t.string('email', { null: false })`, …) and is **not** valid inside the `defineSchema(...)` argument. If you see an error like `Property 'string' does not exist on type '{ ... }'` while filling in a schema, you've reached for `defineTable`'s builder by mistake — pass plain column literals instead.
 
 ```ts
 import { Model, defineSchema } from '@next-model/core';
@@ -107,6 +109,27 @@ Adding `null: true` widens any of the above to `T | null`. Primary columns drive
 `tableName` is statically constrained to keys of `dbSchema.tables`, so a typo like `tableName: 'unknwon'` is a TypeScript error at the Model definition site — and the runtime throws `Model(): tableName 'unknwon' is not declared on the attached schema. Known tables: users, posts` if you bypass the type system.
 
 Each schema entry's `tableDefinitions[name]` is a runtime [`TableDefinition`](#schema-dsl) — the same shape `defineTable(...)` produces for `@next-model/migrations`. Tooling that consumes `TableDefinition` (schema snapshots, GraphQL / OpenAPI generators, admin UIs) can read the schema directly so there's a single source of truth for the table.
+
+The returned schema is iterable for bootstrap-style code — read `Object.keys(schema.tableDefinitions)` (or `Object.entries(...)`) to walk every declared table without touching the type-level `tables` field:
+
+```ts
+const schema = defineSchema({
+  users: { columns: { id: { type: 'integer', primary: true, autoIncrement: true } } },
+  posts: { columns: { id: { type: 'integer', primary: true, autoIncrement: true } } },
+});
+
+for (const tableName of Object.keys(schema.tableDefinitions)) {
+  console.log(tableName);
+  // → 'users'
+  // → 'posts'
+}
+
+for (const [tableName, table] of Object.entries(schema.tableDefinitions)) {
+  console.log(tableName, table.columns.map((c) => c.name));
+}
+```
+
+This is how `connector.ensureSchema()` and the schema-from-db generator walk a schema; the same pattern is useful for app boot diagnostics, fixture seeding, or feeding tables into a generic admin UI.
 
 You can still pass an explicit `init` to coerce or derive fields, or override `keys`:
 
@@ -590,19 +613,21 @@ User.filterBy({ $or: [{ firstName: 'John' }, { firstName: 'Jane' }] });
 User.filterBy({ $not: { gender: 'male' } });
 ```
 
-### orderBy / reorder / reverse / unordered
+### orderBy / withOrder / reverse / unordered
 
 ```ts
 User.orderBy({ key: 'lastName' });
 User.orderBy([{ key: 'lastName' }, { key: 'firstName', dir: SortDirection.Desc }]);
 User.orderBy({ key: 'lastName' }).reverse();     // flip directions
-User.reorder({ key: 'age' });                    // replace existing order
+User.withOrder({ key: 'age' });                  // replace existing order
 User.orderBy({ key: 'age' }).unordered();
 
 // Conventional ORM shape works too — normalised inside the connector:
 User.orderBy({ lastName: 'asc' });
 User.orderBy([{ lastName: 'asc' }, { firstName: 'desc' }]);
 ```
+
+> **`reorder()` is deprecated.** Earlier releases exposed `reorder(order)` as the "replace ORDER BY" chainable, which shadowed user-facing static methods on subclasses (`Item.reorder([…])` for "reorder these items by sortOrder"). Use `withOrder(order)` instead — it does exactly the same thing. `reorder()` still works as a deprecated alias and emits a one-shot `console.warn` per process.
 
 `reverse()` flips the current order; with no order set, it falls back to descending primary key — which makes `Model.last()` reliable without configuration.
 
@@ -982,6 +1007,16 @@ await new User({ email: 'bad', age: 10 }).isValid(); // false
 await user.save();                                   // throws ValidationError if invalid
 ```
 
+> **`validators` is a flat array, not a per-field map.** Every factory takes the column name (or list of column names) as its first argument and returns a single validator function. Drop them all into `validators: [...]` side-by-side — there is no `validators: { email: [...] }` shape. Multiple column-scoped factories can target the same column.
+>
+> ```ts
+> validators: [
+>   validatePresence(['email', 'name']),         // flat array, not per-field map
+>   validateFormat('email', { with: /…/ }),
+>   validateLength('name', { min: 3, max: 50 }),
+> ],
+> ```
+
 ### Built-in validator factories
 
 Eight Rails-style factories ship from `@next-model/core` for the common
@@ -1108,7 +1143,16 @@ await Post.skipCallbacks(['afterCreate', 'afterSave'], async () => {
 
 ## Timestamps
 
-Enabled by default. `createdAt` is set on insert, `updatedAt` on every save. `touch()` updates `updatedAt` without any other changes. Opt out with `timestamps: false`, or pass your own values on insert to override.
+`createdAt` is set on insert, `updatedAt` on every save. `touch()` updates `updatedAt` without any other changes.
+
+The `timestamps:` option is inferred from the schema's column declarations when you don't pass it explicitly:
+
+- Schema declares both `createdAt` + `updatedAt` → enable both (matches the historical default).
+- Schema declares only `createdAt` → behaves as `{ updatedAt: false }`.
+- Schema declares only `updatedAt` → behaves as `{ createdAt: false }`.
+- Schema declares neither → behaves as `timestamps: false`.
+
+This means a plumbing table (sessions, ad-hoc lookups, …) that does not declare timestamp columns no longer fails inserts with `SqliteError: table X has no column named createdAt`. Explicit `timestamps:` always wins — pass `timestamps: false`, `timestamps: true`, or `timestamps: { createdAt: 'inserted_at', updatedAt: false }` to override inference. Pass your own values on insert to override individual rows.
 
 ## Soft deletes
 
@@ -1482,6 +1526,47 @@ await connector.createTable('users', (t) => {
 ```
 
 Copy-pasting from a `defineSchema(...)` schema into a `createTable(...)` builder block now round-trips cleanly.
+
+## Testing with Models
+
+The hydrated instance shape (column getters + association accessors + key readonlys) is intersected at construction time, so direct `new Model(...)` calls or hand-built fixture objects don't satisfy the typed surface — TypeScript will reject reads of getter columns like `m.body` unless the value comes back through `Model.create()` / `Model.find()` / `typeof Model.Instance`.
+
+Reach for a small typed factory helper instead of `as any`:
+
+```ts
+// test-helpers/makeMessage.ts
+import { Message } from '../models/Message';
+
+type MessageProps = Parameters<typeof Message.create>[0];
+
+/**
+ * Typed factory for unit tests: takes the same prop shape as `Message.create`,
+ * persists through the real Model surface, and returns `typeof Message.Instance`
+ * so test assertions on `m.body` / `m.author` typecheck without casts.
+ */
+export async function makeMessage(
+  props: Partial<MessageProps> = {},
+): Promise<typeof Message.Instance> {
+  return Message.create({
+    body: 'placeholder',
+    author: null,
+    ...props,
+  } as MessageProps);
+}
+```
+
+```ts
+// some.spec.ts
+import { makeMessage } from './test-helpers/makeMessage';
+
+it('formats the body', async () => {
+  const m = await makeMessage({ body: 'hello' });
+  expect(m.body).toBe('hello');             // typed — no `as any`
+  expect(formatLine(m)).toBe('hello');
+});
+```
+
+The same pattern scales to every Model: define one `makeX(props?)` helper per Model under `test-helpers/`, key it on `Parameters<typeof X.create>[0]`, and return `typeof X.Instance`. This consolidates the `as any` casts that tend to grow in test fixtures and gives every test a single place to update when a column gets renamed.
 
 ## Errors
 

--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -142,6 +142,30 @@ type SchemaModelClass<
           includes<M>(this: M, ...names: Array<AssocNames<Assoc> | IncludeOptions>): M;
           joins<M>(this: M, ...names: AssocNames<Assoc>[]): M;
           whereMissing<M>(this: M, name: AssocNames<Assoc>): M;
+          /**
+           * Phantom type alias — *only* meaningful in type positions. The runtime
+           * value is always `undefined`. Use `typeof MyModel.Instance` to name
+           * the hydrated instance shape (including column property getters,
+           * association accessors, and persistent-key readonlys) in subclass
+           * static-method return / parameter types without spelling out
+           * `Awaited<ReturnType<typeof MyModel.create>>`.
+           *
+           * @example
+           * ```ts
+           * class Message extends Model({ tableName: 'messages', connector }) {
+           *   static async withBody(id: number): Promise<typeof Message.Instance> {
+           *     return Message.find(id);
+           *   }
+           *   static label(m: typeof Message.Instance): string {
+           *     return `${m.id}: ${m.body}`;
+           *   }
+           * }
+           * ```
+           */
+          Instance: Inst &
+            Assoc &
+            PersistentProps &
+            Readonly<{ [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }>;
         }
       : R
     : never;

--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -688,6 +688,16 @@ export class ModelClass {
     return CollectionQuery.fromModel(this as any).unordered() as unknown as M;
   }
 
+  static withOrder<M extends typeof ModelClass>(this: M, order: Order<any>) {
+    return CollectionQuery.fromModel(this as any).withOrder(order) as unknown as M;
+  }
+
+  /**
+   * @deprecated Use {@link ModelClass.withOrder | withOrder} instead.
+   * Calling `reorder()` emits a one-shot `console.warn` and delegates to
+   * `withOrder()`. The `reorder` name is reserved so subclasses can use it
+   * for domain-specific user-facing methods (e.g. "reorder items by sortOrder").
+   */
   static reorder<M extends typeof ModelClass>(this: M, order: Order<any>) {
     return CollectionQuery.fromModel(this as any).reorder(order) as unknown as M;
   }
@@ -2669,6 +2679,18 @@ function modelFactoryImpl<
       return super.orderBy(order) as M;
     }
 
+    static withOrder<M extends typeof ModelClass>(
+      this: M,
+      order: Order<
+        PersistentProps & { [K in keyof Keys]: Keys[K] extends KeyType.uuid ? string : number }
+      >,
+    ) {
+      return super.withOrder(order) as M;
+    }
+
+    /**
+     * @deprecated Use {@link ModelClass.withOrder | withOrder} instead.
+     */
     static reorder<M extends typeof ModelClass>(
       this: M,
       order: Order<

--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -2521,8 +2521,25 @@ export function Model(props: any): any {
     resolvedSchema.tableDefinitions,
   );
   const schemaColumnNames = tableDefinition.columns.map((c) => c.name);
+  // When the caller does not pass `timestamps` explicitly, peek at the
+  // schema to infer a safe default. Writing `createdAt` / `updatedAt`
+  // on insert against a table that does not declare those columns
+  // surfaces as `SqliteError: table X has no column named createdAt` —
+  // forcing users to remember `timestamps: false` for plumbing tables
+  // (sessions, ad-hoc lookups, ...). Inference:
+  //   - both columns present → keep current default (enable both)
+  //   - only `createdAt` → behave as `{ updatedAt: false }`
+  //   - only `updatedAt` → behave as `{ createdAt: false }`
+  //   - neither column   → behave as `timestamps: false`
+  // Explicit `timestamps:` (any value, including `false` / partial object)
+  // always wins — no inference, no warning.
+  const resolvedTimestamps =
+    props.timestamps === undefined
+      ? inferTimestampsFromSchema(schemaColumnNames)
+      : props.timestamps;
   const result = modelFactoryImpl({
     ...props,
+    timestamps: resolvedTimestamps,
     tableName,
     keys,
     init,
@@ -2531,6 +2548,21 @@ export function Model(props: any): any {
   });
   ModelClass.tableRegistry.set(tableName, result as unknown as typeof ModelClass);
   return result;
+}
+
+/**
+ * Map the schema's declared column set into the inferred default for the
+ * Model factory's `timestamps` option. Only consulted when the caller does
+ * NOT pass `timestamps:` explicitly.
+ */
+function inferTimestampsFromSchema(
+  columnNames: readonly string[],
+): boolean | { createdAt: boolean; updatedAt: boolean } {
+  const hasCreated = columnNames.includes('createdAt');
+  const hasUpdated = columnNames.includes('updatedAt');
+  if (hasCreated && hasUpdated) return true;
+  if (!hasCreated && !hasUpdated) return false;
+  return { createdAt: hasCreated, updatedAt: hasUpdated };
 }
 
 function modelFactoryImpl<

--- a/packages/core/src/__tests__/Model.spec.ts
+++ b/packages/core/src/__tests__/Model.spec.ts
@@ -16,6 +16,10 @@ const fooSchema = defineSchema({
       id: { type: 'integer', primary: true, autoIncrement: true },
       foo: { type: 'string', null: true },
       bar: { type: 'string', null: true },
+      // The default-timestamps tests rely on these columns; declare them so
+      // the timestamps-inference default (schema-aware) keeps them enabled.
+      createdAt: { type: 'datetime', null: true },
+      updatedAt: { type: 'datetime', null: true },
     },
   },
 });

--- a/packages/core/src/__tests__/collectionQueryChain.spec.ts
+++ b/packages/core/src/__tests__/collectionQueryChain.spec.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ModelClass } from '../Model.js';
-import { CollectionQuery } from '../query/CollectionQuery.js';
+import { __resetReorderDeprecationWarning, CollectionQuery } from '../query/CollectionQuery.js';
 import { SortDirection } from '../types.js';
 
 class Todo extends ModelClass {
@@ -21,11 +21,35 @@ describe('CollectionQuery chain methods', () => {
     expect(q.state.order).toEqual([{ key: 'createdAt' }]);
   });
 
-  it('reorder replaces state.order', () => {
+  it('withOrder replaces state.order without warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    __resetReorderDeprecationWarning();
     const q = CollectionQuery.fromModel(Todo as any)
       .orderBy({ key: 'a' as any })
-      .reorder({ key: 'b' as any });
+      .withOrder({ key: 'b' as any });
     expect(q.state.order).toEqual([{ key: 'b' }]);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('reorder is a deprecated alias for withOrder; warns once per process', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    __resetReorderDeprecationWarning();
+    const q1 = CollectionQuery.fromModel(Todo as any)
+      .orderBy({ key: 'a' as any })
+      .reorder({ key: 'b' as any });
+    expect(q1.state.order).toEqual([{ key: 'b' }]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/reorder\(\) is deprecated/);
+    // Second call should NOT warn again (one-shot).
+    const q2 = CollectionQuery.fromModel(Todo as any).reorder({ key: 'c' as any });
+    expect(q2.state.order).toEqual([{ key: 'c' }]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  afterEach(() => {
+    __resetReorderDeprecationWarning();
   });
 
   it('limitBy / skipBy / unlimited / unskipped', () => {

--- a/packages/core/src/__tests__/modelInstanceType.spec.ts
+++ b/packages/core/src/__tests__/modelInstanceType.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { defineSchema, MemoryConnector, Model } from '../index.js';
+
+const schema = defineSchema({
+  messages: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      body: { type: 'string' },
+      author: { type: 'string', null: true },
+    },
+  },
+});
+
+function freshConnector(): MemoryConnector {
+  return new MemoryConnector({ storage: {}, lastIds: {} }, { schema });
+}
+
+class Message extends Model({ tableName: 'messages', connector: freshConnector() }) {
+  // A static returning the hydrated instance shape. Without `typeof Message.Instance`
+  // callers would need a local `Awaited<ReturnType<typeof Message.create>>` alias.
+  static async newest(): Promise<typeof Message.Instance | undefined> {
+    return Message.last();
+  }
+
+  // A static taking the hydrated instance shape as a parameter.
+  static label(m: typeof Message.Instance): string {
+    return `${m.id}: ${m.body}`;
+  }
+}
+
+describe('Model.Instance phantom type', () => {
+  it('typechecks column getters on the hydrated instance shape', async () => {
+    const created = await Message.create({ body: 'hello', author: 'ada' });
+    // Compile-time: assigning a hydrated record to typeof Message.Instance
+    // must accept all known column getters.
+    const m: typeof Message.Instance = created;
+    expectTypeOf(m.id).toEqualTypeOf<number>();
+    expectTypeOf(m.body).toEqualTypeOf<string>();
+    // author is nullable in the schema.
+    expectTypeOf(m.author).toEqualTypeOf<string | null | undefined>();
+    expect(m.body).toBe('hello');
+  });
+
+  it('round-trips through user-defined statics that name typeof Model.Instance', async () => {
+    await Message.create({ body: 'first' });
+    await Message.create({ body: 'second' });
+    const latest = await Message.newest();
+    expect(latest).toBeDefined();
+    if (latest) {
+      // Pass the hydrated record back through a static expecting Instance.
+      expect(Message.label(latest)).toMatch(/^\d+: second$/);
+    }
+  });
+
+  it('rejects access to a non-existent column at compile time', async () => {
+    const created = await Message.create({ body: 'x' });
+    const m: typeof Message.Instance = created;
+    // @ts-expect-error — `nope` is not declared on the schema.
+    void m.nope;
+    expect(m.body).toBe('x');
+  });
+
+  it('runtime value of Model.Instance is undefined (phantom)', () => {
+    expect((Message as { Instance?: unknown }).Instance).toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/persistenceErgonomics.spec.ts
+++ b/packages/core/src/__tests__/persistenceErgonomics.spec.ts
@@ -6,6 +6,9 @@ const schema = defineSchema({
       id: { type: 'integer', primary: true, autoIncrement: true },
       title: { type: 'string' },
       lastSeenAt: { type: 'datetime', null: true },
+      // touch() / default-timestamps tests rely on these.
+      createdAt: { type: 'datetime', null: true },
+      updatedAt: { type: 'datetime', null: true },
     },
   },
 });

--- a/packages/core/src/__tests__/timestampsInference.spec.ts
+++ b/packages/core/src/__tests__/timestampsInference.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { defineSchema, MemoryConnector, Model } from '../index.js';
+
+// Schema with all four combinations of createdAt / updatedAt presence.
+const schema = defineSchema({
+  with_both: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      name: { type: 'string' },
+      createdAt: { type: 'datetime', null: true },
+      updatedAt: { type: 'datetime', null: true },
+    },
+  },
+  only_created: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      name: { type: 'string' },
+      createdAt: { type: 'datetime', null: true },
+    },
+  },
+  only_updated: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      name: { type: 'string' },
+      updatedAt: { type: 'datetime', null: true },
+    },
+  },
+  neither: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      name: { type: 'string' },
+    },
+  },
+});
+
+function freshConnector(): MemoryConnector {
+  return new MemoryConnector({ storage: {}, lastIds: {} }, { schema });
+}
+
+describe('Model factory — inferred timestamps default', () => {
+  it('enables both columns when the schema declares both', async () => {
+    class WithBoth extends Model({ tableName: 'with_both', connector: freshConnector() }) {}
+    const created = await WithBoth.create({ name: 'a' });
+    const attrs = created.attributes as Record<string, unknown>;
+    expect(attrs.createdAt).toBeInstanceOf(Date);
+    expect(attrs.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('disables updatedAt when only createdAt is declared', async () => {
+    class OnlyCreated extends Model({ tableName: 'only_created', connector: freshConnector() }) {}
+    const created = await OnlyCreated.create({ name: 'b' });
+    const attrs = created.attributes as Record<string, unknown>;
+    expect(attrs.createdAt).toBeInstanceOf(Date);
+    // The factory must NOT have tried to write an `updatedAt` column the
+    // schema does not declare.
+    expect('updatedAt' in attrs).toBe(false);
+  });
+
+  it('disables createdAt when only updatedAt is declared', async () => {
+    class OnlyUpdated extends Model({ tableName: 'only_updated', connector: freshConnector() }) {}
+    const created = await OnlyUpdated.create({ name: 'c' });
+    const attrs = created.attributes as Record<string, unknown>;
+    expect(attrs.updatedAt).toBeInstanceOf(Date);
+    expect('createdAt' in attrs).toBe(false);
+  });
+
+  it('disables both when the schema declares neither', async () => {
+    class Neither extends Model({ tableName: 'neither', connector: freshConnector() }) {}
+    const created = await Neither.create({ name: 'd' });
+    const attrs = created.attributes as Record<string, unknown>;
+    expect('createdAt' in attrs).toBe(false);
+    expect('updatedAt' in attrs).toBe(false);
+  });
+
+  it('explicit timestamps: false wins even when both columns exist', async () => {
+    class WithBothOff extends Model({
+      tableName: 'with_both',
+      connector: freshConnector(),
+      timestamps: false,
+    }) {}
+    const created = await WithBothOff.create({ name: 'e' });
+    const attrs = created.attributes as Record<string, unknown>;
+    expect('createdAt' in attrs).toBe(false);
+    expect('updatedAt' in attrs).toBe(false);
+  });
+
+  it('explicit timestamps: true wins (matches old default) when both columns exist', async () => {
+    class WithBothOn extends Model({
+      tableName: 'with_both',
+      connector: freshConnector(),
+      timestamps: true,
+    }) {}
+    const created = await WithBothOn.create({ name: 'f' });
+    const attrs = created.attributes as Record<string, unknown>;
+    expect(attrs.createdAt).toBeInstanceOf(Date);
+    expect(attrs.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('partial-object timestamps disable inference (createdAt only)', async () => {
+    class CustomOnlyCreated extends Model({
+      tableName: 'only_created',
+      connector: freshConnector(),
+      timestamps: { createdAt: true, updatedAt: false },
+    }) {}
+    const created = await CustomOnlyCreated.create({ name: 'g' });
+    const attrs = created.attributes as Record<string, unknown>;
+    expect(attrs.createdAt).toBeInstanceOf(Date);
+    expect('updatedAt' in attrs).toBe(false);
+  });
+});

--- a/packages/core/src/query/CollectionQuery.ts
+++ b/packages/core/src/query/CollectionQuery.ts
@@ -35,6 +35,22 @@ import {
 
 type ModelLike = { tableName: string; keys: Dict<KeyType> };
 
+let reorderDeprecationWarned = false;
+function warnReorderDeprecated(): void {
+  if (reorderDeprecationWarned) return;
+  reorderDeprecationWarned = true;
+  // biome-ignore lint/suspicious/noConsole: one-shot deprecation notice
+  console.warn(
+    'reorder() is deprecated; use withOrder() instead. ' +
+      'The reorder() name is reserved so user-facing static methods on subclasses can use it freely.',
+  );
+}
+
+/** @internal Test-only reset for the one-shot reorder deprecation flag. */
+export function __resetReorderDeprecationWarning(): void {
+  reorderDeprecationWarned = false;
+}
+
 // Build a temp Model subclass carrying QueryState fields as static properties.
 // Used by chain methods that delegate to a Model static (named scopes, enum
 // scopes, etc.) so the static reads `this.<x>` sees the chained scope.
@@ -378,8 +394,19 @@ export class CollectionQuery<Items = unknown[]> implements PromiseLike<Items> {
     return this.with({ order: mergeOrders(this.state.order, next) });
   }
 
-  reorder(order: Order<any>): this {
+  withOrder(order: Order<any>): this {
     return this.with({ order: Array.isArray(order) ? [...order] : [order] });
+  }
+
+  /**
+   * @deprecated Use {@link CollectionQuery.withOrder | withOrder} instead.
+   * Calling `reorder()` emits a one-shot `console.warn` and delegates to
+   * `withOrder()`. The `reorder` name is reserved so subclasses can use it
+   * for domain-specific user-facing methods (e.g. "reorder items by sortOrder").
+   */
+  reorder(order: Order<any>): this {
+    warnReorderDeprecated();
+    return this.withOrder(order);
   }
 
   unordered(): this {
@@ -883,7 +910,7 @@ export class CollectionQuery<Items = unknown[]> implements PromiseLike<Items> {
     const otherSkip = other instanceof CollectionQuery ? other.state.skip : other.skip;
     let q: this = this;
     if (otherFilter) q = q.filterBy(otherFilter);
-    if (otherOrder && otherOrder.length > 0) q = q.reorder(otherOrder);
+    if (otherOrder && otherOrder.length > 0) q = q.withOrder(otherOrder);
     if (otherLimit !== undefined) q = q.limitBy(otherLimit);
     if (otherSkip !== undefined) q = q.skipBy(otherSkip);
     return q;

--- a/packages/core/src/query/CollectionQuery.ts
+++ b/packages/core/src/query/CollectionQuery.ts
@@ -39,7 +39,6 @@ let reorderDeprecationWarned = false;
 function warnReorderDeprecated(): void {
   if (reorderDeprecationWarned) return;
   reorderDeprecationWarned = true;
-  // biome-ignore lint/suspicious/noConsole: one-shot deprecation notice
   console.warn(
     'reorder() is deprecated; use withOrder() instead. ' +
       'The reorder() name is reserved so user-facing static methods on subclasses can use it freely.',

--- a/packages/sqlite-connector/HISTORY.md
+++ b/packages/sqlite-connector/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Docs
+
+- Electron integration section added: BrowserWindow flags, preload bridge under `contextIsolation: false` (direct `window.leitn = api` assignment instead of `contextBridge.exposeInMainWorld(...)`, which is a no-op there), Vite renderer config (`optimizeDeps.exclude` for `better-sqlite3` + `@next-model/sqlite-connector`, a `transform` plugin that rewrites the `better-sqlite3` import to `window.require(...)`), and a renderer top-level-await bootstrap (`new SqliteConnector(dbPath, { schema })` → `await connector.ensureSchema()` → `createRoot(...).render(<App />)`). Includes the `window.require('fs')` gotcha for renderer-side filesystem work (Vite stubs `node:fs`).
+
 ## v1.1.2
 
 ### Added

--- a/packages/sqlite-connector/README.md
+++ b/packages/sqlite-connector/README.md
@@ -190,6 +190,118 @@ Both use `RETURNING *` so the affected rows are returned in one round-trip. `LIM
 
 `{ default: 'currentTimestamp' }` becomes `DEFAULT CURRENT_TIMESTAMP`. `t.index([col], { unique })` issues a follow-up `CREATE [UNIQUE] INDEX … ON tbl (col)` after the table create. `dropTable` uses `DROP TABLE IF EXISTS`.
 
+## Electron integration
+
+`@next-model/sqlite-connector` works inside an Electron renderer when the renderer can `require` Node modules (typically `nodeIntegration: true`, `contextIsolation: false` or via a preload bridge). This section documents the wiring that surfaced repeatedly during downstream integration.
+
+### Main-process side (BrowserWindow + preload)
+
+```ts
+// electron-main.ts
+import { app, BrowserWindow } from 'electron';
+import path from 'node:path';
+
+app.whenReady().then(() => {
+  const win = new BrowserWindow({
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.cjs'),
+      // The simplest configuration when you want `better-sqlite3` to load in
+      // the renderer with a real Node `require`. If you keep
+      // `contextIsolation: true`, route the connector through the main
+      // process via IPC instead — `better-sqlite3` cannot cross the
+      // structured-clone boundary.
+      contextIsolation: false,
+      nodeIntegration: true,
+    },
+  });
+  win.loadFile('dist/index.html');
+});
+```
+
+### Preload bridge under `contextIsolation: false`
+
+`contextBridge.exposeInMainWorld(...)` is a no-op when `contextIsolation` is false — it only populates `window` inside the isolated world. Under `contextIsolation: false` you must assign directly:
+
+```ts
+// preload.cjs
+const { ipcRenderer } = require('electron');
+
+// Direct assignment — works under contextIsolation: false.
+// `contextBridge.exposeInMainWorld` would NOT populate `window` here.
+window.leitn = {
+  paths: {
+    appData: () => ipcRenderer.invoke('paths:appData'),
+  },
+};
+```
+
+### Vite renderer config
+
+Renderer bundlers (Vite, Webpack, …) don't know how to bundle the native
+`better-sqlite3` binding. Exclude both `better-sqlite3` and
+`@next-model/sqlite-connector` from optimization and rewrite the
+`better-sqlite3` import to a runtime `require()` so the renderer pulls
+the Node module from disk at boot:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  optimizeDeps: {
+    exclude: ['better-sqlite3', '@next-model/sqlite-connector'],
+  },
+  plugins: [
+    {
+      name: 'better-sqlite3-require-shim',
+      enforce: 'pre',
+      // Rewrite `import Database from 'better-sqlite3'` so the renderer
+      // resolves the native binding through Node's `require()` at runtime
+      // instead of letting Vite try to bundle the .node binary.
+      transform(code, id) {
+        if (!id.endsWith('.ts') && !id.endsWith('.tsx')) return null;
+        if (!code.includes("from 'better-sqlite3'")) return null;
+        return code.replace(
+          /import\s+(\w+)\s+from\s+'better-sqlite3'/g,
+          "const $1 = window.require('better-sqlite3')",
+        );
+      },
+    },
+  ],
+});
+```
+
+A future `@next-model/sqlite-connector/vite` entrypoint may ship this transform out of the box — for this release we document the snippet.
+
+### Renderer bootstrap
+
+The renderer typically wants to mount the React tree only after the connector exists and the schema is materialised. Top-level `await` works in modern bundlers; the bootstrap chain looks like:
+
+```ts
+// renderer/main.tsx
+import { createRoot } from 'react-dom/client';
+import { SqliteConnector } from '@next-model/sqlite-connector';
+import { schema } from './db/schema';
+import { App } from './App';
+
+// `window.require('fs')` instead of `import 'node:fs'` — Vite stubs the
+// `node:fs` builtin in the renderer bundle and crashes at runtime.
+const fs = window.require('fs');
+const appData: string = await window.leitn.paths.appData();
+fs.mkdirSync(appData, { recursive: true });
+const dbPath = `${appData}/app.sqlite`;
+
+const connector = new SqliteConnector(dbPath, { schema });
+await connector.ensureSchema();
+
+createRoot(document.getElementById('root')!).render(<App connector={connector} />);
+```
+
+The two gotchas worth calling out:
+
+- `node:fs` is stubbed in the renderer bundle; reach for `window.require('fs')` for any renderer-side filesystem work.
+- Always `await connector.ensureSchema()` before mounting the tree — Model reads issued before tables exist surface as opaque `no such table: …` errors deep inside `useSyncExternalStore` consumers.
+
 ## Testing matrix
 
 The shared `runModelConformance` suite (every Model feature) runs against an in-memory database every commit — no service container required.


### PR DESCRIPTION
## Motivation

Third batch of dogfooding fixes. PR #178 + #179 landed the critical
API issues. This PR cleans up the remaining medium ergonomic gaps and
fills the documentation holes that surfaced during integration.

## Fixes

- `withOrder(order)` chainable; deprecated `reorder()` alias frees the name for user-facing methods.
- `Model.Instance` phantom type so subclass statics returning instances don't need a local `Awaited<ReturnType<typeof Model.create>>` alias.
- Inferred `timestamps` default from schema column presence (created/updated). Explicit `timestamps: ...` still wins.
- README sections covering Electron integration (preload + Vite shim), `defineSchema` vs `defineTable`, `tableDefinitions` iteration, validators-array shape, testing patterns, and the renderer top-level-await bootstrap example.

## Behaviour change

None for the chainable / type-alias additions.

Schema-aware `timestamps` inference only kicks in when `timestamps:` is unspecified — explicit values are honored verbatim. The one place it bites is the niche case where a Model was wired to a table that does NOT declare `createdAt` / `updatedAt`; previously the factory tried to write those columns anyway and inserts failed with `SqliteError: table X has no column named createdAt`. After this PR they succeed silently. Two internal test fixtures (`Model.spec` foo, `persistenceErgonomics.spec` posts) gained those columns to preserve their existing test semantics under the new schema-aware default.