### PR TITLE
feat(core): make Model instances structured-clone friendly

### DIFF
--- a/packages/core/HISTORY.md
+++ b/packages/core/HISTORY.md
@@ -2,6 +2,14 @@
 
 ## vNext
 
+### Changed
+
+- Column accessors installed on every Model instance (schema columns, persistent-prop columns, primary-key columns, and `storeAccessors` sub-keys) are now `enumerable: true`. This makes raw Model instances structured-clone-friendly: `structuredClone(instance)` invokes each getter and stores the value on the clone, so receivers across structured-clone boundaries (Electron IPC, Web Workers, `BroadcastChannel`) see the column shape they expect instead of only the internal bookkeeping fields (`persistentProps`, `changedProps`, `lastSavedChanges`, `keys`). **Observable behaviour change** — `Object.keys(instance)` and `for (const k in instance)` now surface column names alongside the bookkeeping fields; any consumer code that enumerated instances expecting just the bookkeeping shape will now see more keys. `JSON.stringify(instance)` is unaffected (still routes through `toJSON()`). Note: `@next-model/react` wraps instances in a `Proxy` for reactivity; Proxies are unconditionally non-cloneable in V8/Chromium, so this change benefits raw instances only — consumers crossing IPC must still extract attributes from the Proxy via `instance.toJSON()` or `instance.attributes` first. See the README's "Serialization → Structured clone / IPC" section for the full pattern.
+
+### Docs
+
+- README `Serialization` section adds a "Structured clone / IPC" subsection covering the Electron renderer-to-main and Web Worker boundaries: which clone variant works on raw instances vs. `@next-model/react` Proxies, when to reach for `.toJSON()` / `.attributes`, and why.
+
 ## v1.1.4
 
 ### Added

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -946,6 +946,33 @@ user.pick(['firstName', 'lastName']);
 user.omit(['createdAt', 'updatedAt']);
 ```
 
+### Structured clone / IPC
+
+Column accessors on Model instances are installed as **enumerable** own properties, so a raw instance survives the structured clone algorithm (Electron IPC, Web Workers, `BroadcastChannel`, `postMessage`) with its column values at the top level:
+
+```ts
+const user = await User.findBy({ isDefault: true });
+const clone = structuredClone(user);
+clone.id;        // ✓ readable on the clone
+clone.firstName; // ✓ readable on the clone
+```
+
+Two caveats when crossing the boundary:
+
+1. **`@next-model/react` Proxies are not cloneable.** The hook layer (`useModel`, `useWatch`, `useAsyncTerminal`) wraps row instances in a `Proxy` for reactivity. `Proxy` is unconditionally non-cloneable in V8 / Chromium — `structuredClone(proxy)` and `port.postMessage(proxy)` both throw `DataCloneError: ... could not be cloned`. Extract a plain object with `instance.toJSON()` or `instance.attributes` before handing it to `ipcRenderer.invoke(...)` / `worker.postMessage(...)`:
+
+   ```ts
+   // ❌ throws "An object could not be cloned" when `user` is wrapped
+   await ipcRenderer.invoke('something', { user });
+
+   // ✓ works regardless of whether `user` is wrapped or raw
+   await ipcRenderer.invoke('something', { user: user.toJSON() });
+   ```
+
+   `.toJSON()` works on both wrapped and raw instances (the Proxy forwards the call to its target), so it's the safest single pattern.
+
+2. **Clone keeps the internal bookkeeping fields.** A cloned raw instance carries the column values *and* the `persistentProps` / `changedProps` / `lastSavedChanges` / `keys` shadows. Consumers that want only the wire-shape columns should use `.toJSON()` (or `JSON.parse(JSON.stringify(instance))` when datetime columns need to round-trip to ISO strings).
+
 ## Attribute boundary helpers
 
 ### normalizes

--- a/packages/core/src/Model.ts
+++ b/packages/core/src/Model.ts
@@ -1563,6 +1563,17 @@ export class ModelClass {
     // value but `instance.archivedAt` would still read `undefined` until
     // re-fetched. Falling back to `persistentProps` keeps the previous
     // behaviour for any Model built without a schema column list.
+    // Column accessors are installed enumerable so that:
+    //  - `Object.keys(instance)` / `for (const k in instance)` surfaces the
+    //    schema columns (matches the user-facing mental model: `instance.id`
+    //    is a column, not just `instance.persistentProps.id`).
+    //  - `structuredClone(instance)` invokes each getter and stores the value
+    //    on the clone. Otherwise the clone would carry only the internal
+    //    bookkeeping fields (`persistentProps`, `changedProps`, …) and
+    //    receivers across structured-clone boundaries (Electron IPC, Web
+    //    Workers, `BroadcastChannel`) would see the wrong shape.
+    //  - `JSON.stringify(instance)` is unaffected — it goes through `toJSON()`
+    //    regardless of property enumerability.
     const installed = new Set<string>();
     const schemaCols = model.schemaColumnNames ?? [];
     for (const key of schemaCols) {
@@ -1570,6 +1581,7 @@ export class ModelClass {
       Object.defineProperty(this, key, {
         get: () => this.attributes[key],
         set: (value) => this.assign({ [key]: value }),
+        enumerable: true,
         configurable: true,
       });
     }
@@ -1578,6 +1590,7 @@ export class ModelClass {
       Object.defineProperty(this, key, {
         get: () => this.attributes[key],
         set: (value) => this.assign({ [key]: value }),
+        enumerable: true,
         configurable: true,
       });
     }
@@ -1591,6 +1604,7 @@ export class ModelClass {
     for (const key in model.keys) {
       Object.defineProperty(this, key, {
         get: () => (this.keys ? this.keys[key] : undefined),
+        enumerable: true,
         configurable: true,
       });
     }
@@ -1620,6 +1634,8 @@ export class ModelClass {
             const current = ((this.attributes as Dict<any>)[column] ?? {}) as Dict<any>;
             this.assign({ [column]: { ...current, [subKey]: value } });
           },
+          enumerable: true,
+          configurable: true,
         });
       }
     }

--- a/packages/core/src/__tests__/instanceEnumeration.spec.ts
+++ b/packages/core/src/__tests__/instanceEnumeration.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { defineSchema, MemoryConnector, Model } from '../index.js';
+
+const schema = defineSchema({
+  users: {
+    columns: {
+      id: { type: 'integer', primary: true, autoIncrement: true },
+      name: { type: 'string' },
+      bio: { type: 'string', null: true },
+      // Default-timestamps inference looks for these columns; declare them so
+      // the test schema keeps the historical createdAt/updatedAt enabled.
+      createdAt: { type: 'datetime', null: true },
+      updatedAt: { type: 'datetime', null: true },
+    },
+  },
+});
+
+function buildUser() {
+  const connector = new MemoryConnector({ storage: {}, lastIds: {} }, { schema });
+  return class User extends Model({ tableName: 'users', connector }) {};
+}
+
+describe('Model instance — column accessor enumerability', () => {
+  it('exposes schema columns as enumerable own properties', async () => {
+    const User = buildUser();
+    const u = await User.create({ name: 'Ada' });
+    const keys = Object.keys(u);
+    expect(keys).toEqual(expect.arrayContaining(['id', 'name', 'bio', 'createdAt', 'updatedAt']));
+  });
+
+  it('column getters are accessor descriptors, not data fields', async () => {
+    // The accessor identity matters: writes through `instance.col = v` must
+    // still flow through `assign(...)`, not become plain own data props that
+    // bypass dirty tracking.
+    const User = buildUser();
+    const u = await User.create({ name: 'Ada' });
+    const desc = Object.getOwnPropertyDescriptor(u, 'name');
+    expect(desc?.enumerable).toBe(true);
+    expect(typeof desc?.get).toBe('function');
+    expect(typeof desc?.set).toBe('function');
+  });
+
+  it('survives structuredClone with the column values at the top level', async () => {
+    // Electron IPC, Web Workers and BroadcastChannel all use the structured
+    // clone algorithm. Receivers across that boundary must see the column
+    // shape — historically the clone only carried `persistentProps`,
+    // `changedProps`, `lastSavedChanges`, `keys` because column getters were
+    // non-enumerable.
+    const User = buildUser();
+    const u = await User.create({ name: 'Ada', bio: 'mathematician' });
+    const clone = structuredClone(u) as Record<string, unknown>;
+    expect(clone.name).toBe('Ada');
+    expect(clone.bio).toBe('mathematician');
+    expect(typeof clone.id).toBe('number');
+  });
+
+  it('exposes storeAccessor sub-keys as enumerable own properties', async () => {
+    // JSON-column sub-key accessors are installed on every instance via the
+    // `storeAccessors` factory option. They should follow the same
+    // enumerability rule as ordinary column accessors so consumers can
+    // discover them via `Object.keys` / `structuredClone`.
+    const localSchema = defineSchema({
+      profiles: {
+        columns: {
+          id: { type: 'integer', primary: true, autoIncrement: true },
+          settings: { type: 'json', null: true },
+        },
+      },
+    });
+    const connector = new MemoryConnector({ storage: {}, lastIds: {} }, { schema: localSchema });
+    class Profile extends Model({
+      tableName: 'profiles',
+      connector,
+      timestamps: false,
+      storeAccessors: { settings: ['theme', 'locale'] },
+    }) {}
+    const p = await Profile.create({ settings: { theme: 'dark', locale: 'en' } });
+    const keys = Object.keys(p);
+    expect(keys).toContain('theme');
+    expect(keys).toContain('locale');
+    const themeDesc = Object.getOwnPropertyDescriptor(p, 'theme');
+    expect(themeDesc?.enumerable).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Mark every column accessor installed on a Model instance — schema columns, persistent-prop columns, primary-key columns, and `storeAccessors` sub-keys — as `enumerable: true`.
- Raw Model instances now survive `structuredClone(...)` with their column values at the top level. This unblocks Electron IPC, Web Workers, `BroadcastChannel`, and `postMessage` consumers that previously received only the internal bookkeeping fields (`persistentProps`, `changedProps`, `lastSavedChanges`, `keys`).
- New `Serialization → Structured clone / IPC` section in `packages/core/README.md` documents the pattern and the one caveat: `@next-model/react`'s reactive `Proxy` wrapper is still unconditionally non-cloneable in V8, so consumers crossing IPC must extract attributes via `.toJSON()` / `.attributes` first.

## Motivation

Discovered while debugging an Electron app: `ipcRenderer.invoke('listRepos', { user })` was throwing `DataCloneError: An object could not be cloned`. The `user` was a `@next-model/react`-wrapped row instance, but even raw instances cloned into the wrong shape (only the bookkeeping fields) because column getters were installed with `enumerable: false`. Now raw instances clone with the expected column shape; wrapped instances still need `.toJSON()` because Proxies cannot pass V8's structured clone (this is a V8-level constraint, not something the library can work around).

## Observable behaviour change

`Object.keys(instance)` and `for (const k in instance)` now surface column names alongside the bookkeeping fields. Any consumer code that enumerated instances expecting just the bookkeeping shape will now see more keys. `JSON.stringify(instance)` is unaffected — it still routes through `toJSON()` regardless of enumerability. The change is documented under `HISTORY.md` (`vNext`).

## Test plan

- [x] New `packages/core/src/__tests__/instanceEnumeration.spec.ts` covers: column accessors are enumerable; descriptors remain accessor (getter/setter) not data; `structuredClone(instance)` produces a clone with column values readable at the top level; `storeAccessors` sub-keys are also enumerable.
- [x] Full `pnpm run ci` (lint + typecheck + tests) green: 5827 tests in core, all dependent packages (react, sqlite-connector, knex-connector, local-storage-connector, aurora-data-api-connector, express-rest-api, graphql-api, nextjs-api, migrations, migrations-generator, zod, typebox, arktype) pass with no regressions.
- [x] DB-connector packages requiring real infrastructure (mysql, mariadb, postgres, mongodb, redis, valkey) were not exercised locally — same as before this change.