### PR TITLE
fix(sqlite-connector): track existing tables on ensureSchema

### DIFF
--- a/packages/sqlite-connector/HISTORY.md
+++ b/packages/sqlite-connector/HISTORY.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Fixed
+
+- `ensureSchema()` now registers the json / boolean column tracking (and the in-memory `tableDefinitions` entry) for tables that already exist on disk, not just for tables it creates on this boot. Before, the second-and-later boot of any file-backed database left those Maps empty for every pre-existing table, so `hydrateRow` skipped the SQLite `0` / `1` → `false` / `true` coercion and json columns came back as raw TEXT. The leak surfaced loudly at Zod / arktype / validator boundaries downstream with `Expected boolean, received number`; same root cause for json columns coming back unparsed. `createTable` is unchanged — the populate path it already did is now extracted into a private `trackTableDefinition(tableName, def)` helper that `ensureSchema` also calls on the existing-table branch.
+
 ## v1.1.5
 
 ## v1.1.4

--- a/packages/sqlite-connector/src/SqliteConnector.ts
+++ b/packages/sqlite-connector/src/SqliteConnector.ts
@@ -810,21 +810,40 @@ export class SqliteConnector<S extends DatabaseSchema<any> | undefined = undefin
 
   async createTable(tableName: string, blueprint: (t: TableBuilder) => void): Promise<void> {
     const def = defineTable(tableName, blueprint);
-    this.tableDefinitions.set(tableName, def);
-    const jsonCols = new Set(def.columns.filter((c) => c.type === 'json').map((c) => c.name));
-    if (jsonCols.size > 0) this.jsonColumns.set(tableName, jsonCols);
-    const boolCols = new Set(def.columns.filter((c) => c.type === 'boolean').map((c) => c.name));
-    if (boolCols.size > 0) this.booleanColumns.set(tableName, boolCols);
+    this.trackTableDefinition(tableName, def);
     if (await this.hasTable(tableName)) return;
     this.runStatement(this.buildCreateTableSql(tableName, def, [], []));
     for (const idx of def.indexes) await this.createIndex(tableName, idx);
   }
 
   /**
+   * Record `tableDefinitions` / `jsonColumns` / `booleanColumns` entries for a
+   * table the connector now knows about. Idempotent — re-registering with the
+   * same definition is a no-op. Used by `createTable` for fresh tables and by
+   * `ensureSchema` for tables that already exist on disk; without the latter
+   * call, `hydrateRow` would pass raw 0/1 INTEGER values through for boolean
+   * columns and leave json columns unparsed on every read against a returning
+   * (already-migrated) database.
+   */
+  private trackTableDefinition(tableName: string, def: TableDefinition): void {
+    this.tableDefinitions.set(tableName, def);
+    const jsonCols = new Set(def.columns.filter((c) => c.type === 'json').map((c) => c.name));
+    if (jsonCols.size > 0) this.jsonColumns.set(tableName, jsonCols);
+    else this.jsonColumns.delete(tableName);
+    const boolCols = new Set(def.columns.filter((c) => c.type === 'boolean').map((c) => c.name));
+    if (boolCols.size > 0) this.booleanColumns.set(tableName, boolCols);
+    else this.booleanColumns.delete(tableName);
+  }
+
+  /**
    * Materialise every table declared in the attached `schema` idempotently.
    * Iterates `schema.tableDefinitions`, skipping tables that already exist
    * and dispatching unknown tables through this connector's `createTable`
-   * so SQLite-specific column-type rendering applies.
+   * so SQLite-specific column-type rendering applies. For tables that already
+   * exist on disk we still register the json/boolean column kinds and the
+   * tracked table definition — otherwise row hydration (boolean 0/1 → false/
+   * true, json TEXT → parsed value) and the alter-table fallbacks would
+   * silently no-op on every boot after the first.
    */
   async ensureSchema(): Promise<{ created: string[]; existing: string[] }> {
     if (!this.schema) {
@@ -836,11 +855,12 @@ export class SqliteConnector<S extends DatabaseSchema<any> | undefined = undefin
     const existing: string[] = [];
     const tableDefinitions = this.schema.tableDefinitions as Record<string, TableDefinition>;
     for (const tableName of Object.keys(tableDefinitions)) {
+      const def = tableDefinitions[tableName];
       if (await this.hasTable(tableName)) {
+        this.trackTableDefinition(tableName, def);
         existing.push(tableName);
         continue;
       }
-      const def = tableDefinitions[tableName];
       await this.createTable(tableName, (t) => {
         for (const col of def.columns) {
           const options: ColumnOptions = {

--- a/packages/sqlite-connector/src/__tests__/booleanCoercion.spec.ts
+++ b/packages/sqlite-connector/src/__tests__/booleanCoercion.spec.ts
@@ -84,6 +84,36 @@ describe('SqliteConnector boolean coercion (read path)', () => {
     expect(rows.map((r) => r.flag).sort()).toEqual([0, 1]);
   });
 
+  it('coerces booleans on returning databases where ensureSchema sees existing tables', async () => {
+    // Simulates the "second boot" path: tables already exist on disk, so
+    // ensureSchema hits the skip branch instead of dispatching createTable.
+    // The boolean-column tracking Map must still be populated, or hydrateRow
+    // passes raw 0/1 INTEGER values through and downstream Zod / boolean
+    // validators reject them with "Expected boolean, received number".
+    const c = new SqliteConnector(':memory:', { schema });
+    connector = c;
+    // First "boot" — create the table.
+    await c.ensureSchema();
+    await c.batchInsert('toggles', { id: 1 } as any, [
+      { isDefault: true, nullableFlag: false, label: 'a' },
+    ]);
+    // Drop the tracking Maps to mimic a fresh connector pointed at the same
+    // file: the table exists, but the in-process bookkeeping is empty until
+    // ensureSchema repopulates it.
+    (c as unknown as { booleanColumns: Map<string, Set<string>> }).booleanColumns.clear();
+    (c as unknown as { jsonColumns: Map<string, Set<string>> }).jsonColumns.clear();
+    (c as unknown as { tableDefinitions: Map<string, unknown> }).tableDefinitions.clear();
+    // Second "boot" — ensureSchema should re-register the tracking entry
+    // even though the table is already present.
+    const result = await c.ensureSchema();
+    expect(result.created).toEqual([]);
+    expect(result.existing).toEqual(['toggles']);
+    const [row] = await c.query({ tableName: 'toggles' });
+    expect(row.isDefault).toBe(true);
+    expect(row.nullableFlag).toBe(false);
+    expect(row.isDefault === true).toBe(true);
+  });
+
   it('does not touch non-boolean columns even when both kinds coexist', async () => {
     const mixedSchema = defineSchema({
       mixed: {


### PR DESCRIPTION
## Summary

`SqliteConnector.ensureSchema()` only registered the in-process `jsonColumns` / `booleanColumns` / `tableDefinitions` tracking for tables it *created* on this boot. On every subsequent boot the tables already existed, the skip branch ran, and the tracking Maps stayed empty — so `hydrateRow` passed raw SQLite `0`/`1` INTEGER values through for boolean columns and left json columns as unparsed TEXT.

Downstream this surfaces loudly the first time a hydrated row crosses a strict boundary — e.g. a Zod schema (`isDefault: z.boolean()`) sent over Electron IPC rejects with **"Expected boolean, received number"**. Same root cause for json columns coming back as raw TEXT.

Fix:

- Extract the populate path `createTable` already did into a private `trackTableDefinition(tableName, def)` helper.
- Call it from `ensureSchema` on the existing-table branch as well, so the tracking maps populate on every boot, fresh or returning.
- Idempotent: re-registering with the same definition is a no-op. Tables that lose all boolean/json columns have their entries cleared so the maps stay in sync if the attached schema changes between boots.
- `createTable` behaviour is unchanged — it now routes through the same helper.

Adds a regression test in `booleanCoercion.spec.ts` that simulates the returning-database path (ensureSchema → insert → drop in-memory tracking → ensureSchema again → read row) and asserts strict `=== true` / `=== false` identity.

## Test plan

- [x] `pnpm --filter @next-model/sqlite-connector test` — 5 files, 119 tests pass (including the new regression test)
- [x] `pnpm --filter @next-model/migrations test` — 4 files, 99 tests pass
- [x] `pnpm -r typecheck` — clean across the workspace
- [x] `pnpm lint` — clean