### PR TITLE
feat(react): auto-tracking shells via .run() terminal + filter-column refetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/superpowers/
 # AI Tools
 .claude
 .playwright-mcp/
+*.tgz

--- a/packages/react/HISTORY.md
+++ b/packages/react/HISTORY.md
@@ -2,6 +2,33 @@
 
 ## vNext
 
+### Added
+
+- **`.run()` terminal on `PendingResult<T>`.** Imperative counterpart to `.fetch()` / `.watch()` — returns a `Promise<T>` whose instances are store-tagged reactive shells. Safe to call from event handlers, mutation callbacks, or any non-render async code:
+
+  ```ts
+  const Task = useModel(TaskModel);
+  const row = await Task.find(id).run();          // tagged shell
+  await row.update({ title: 'new' });              // auto-publishes; watches refire
+  ```
+
+  Previously the only way to get a tagged instance was through a live `.watch(...)` — `Model.find(id)` outside a watch returned an untagged raw instance, silently losing reactivity on subsequent `.update()` / `.delete()` calls. `.run()` closes that gap and makes "look up by id then mutate" a first-class pattern.
+
+- **Auto-refetch collection watches on filter-column mutations.** Mutations now broadcast `col:<table>:<column>` for each column whose persistent value actually changes. Collection watches walk their `filterBy` / `whereMissing` chain at mount, extract every column name the predicates reference, and subscribe to the matching column keys — refetching when any fires.
+
+  This means `update({ archivedAt: new Date() })` against a watch with `filterBy({ $null: 'archivedAt' })` now correctly drops the row from the visible list (and the reverse — clearing `archivedAt` brings a previously-hidden row INTO the watch). No manual `useInvalidateKeys` call required for filter-flipping mutations.
+
+  Supported predicate shapes: plain `{ col: value }`, `$null` / `$notNull` keyed by column name, `$in` / `$notIn` / `$between` keyed by column, recursive `$and` / `$or` arrays, and `$not`. Unknown `$`-operators are ignored.
+
+  Mutated columns are computed *before* the call runs:
+  - `update(patch)` — diff `patch` against `persistentProps` so only actually-changed columns broadcast.
+  - `save()` — read `changedProps` keys.
+  - `increment(col)` / `decrement(col)` — the arg names the column.
+
+### Changed
+
+- `useAsyncTerminal` and `useWatch` now share `adopt` / `decorate` from a new internal `adoptInstance` module — both paths reconcile against the store's identity map (previously `useAsyncTerminal`'s adopt was simpler and didn't soft-register, which meant instances from `.fetch()` could diverge from the canonical shell in the store).
+
 ## v1.1.6
 
 ## v1.1.5

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -63,12 +63,13 @@ function NewTaskForm() {
 }
 ```
 
-#### Chain terminals — `PendingResult<T>` — call `.fetch()` or `.watch()`
+#### Chain terminals — `PendingResult<T>` — call `.fetch()`, `.watch()`, or `.run()`
 
 Terminal methods (`all`, `find`, `findBy`, `first`, `last`, `findOrFail`, `count`, `sum`, `min`, `max`, `avg`, `pluck`, `exists`) are **chain steps** — they record the terminal in the plan and return a `PendingResult<T>` without invoking any React hook. To execute:
 
-- `.fetch()` — one-shot async fetch: returns `AsyncResult<T>` (`{ data, isLoading, error }`)
-- `.watch(opts?)` — live subscription: returns `WatchResult<T>` (`{ data, isLoading, isRefetching, error }`)
+- `.fetch()` — one-shot async fetch: returns `AsyncResult<T>` (`{ data, isLoading, error }`) — hook, render-time only
+- `.watch(opts?)` — live subscription: returns `WatchResult<T>` (`{ data, isLoading, isRefetching, error }`) — hook, render-time only
+- `.run()` — imperative: returns `Promise<T>` whose instances are store-tagged reactive shells. Safe to call from event handlers, mutation callbacks, or any non-render async code. Subsequent `.update()` / `.delete()` calls on the returned shell auto-publish and refire any active watches on the same row.
 
 | Terminal | `T` for `.fetch()` / `.watch()` |
 |---|---|
@@ -92,6 +93,20 @@ const { data: todo } = useModel(Todo).find(id).watch();
 const { data: todos } = useModel(Todo).filterBy({ userId }).watch({
   keys: [`todos-user:${userId}`],
 });
+
+// Imperative lookup + mutate from an event handler — sibling watches refire
+// automatically. No `useInvalidateKeys` call needed for the mutation itself.
+function ToggleButton({ id }: { id: number }) {
+  const Todo = useModel(TodoModel);
+  return (
+    <button onClick={async () => {
+      const row = await Todo.find(id).run();
+      if (row) await row.update({ done: !row.done });
+    }}>
+      toggle
+    </button>
+  );
+}
 ```
 
 #### Shortcut: implicit-all `.fetch()` / `.watch()`
@@ -107,8 +122,13 @@ const { data } = useModel(Todo).filterBy({ done: false }).watch({ keys: ['todos'
 // Watch behaviour:
 // - In-place updates on save: row stays in `data` with fresh attributes.
 // - Deleted rows drop from `data`.
-// - New rows are not auto-added — call `useInvalidateKeys()` to refetch.
-// - Filters are not auto re-evaluated client-side.
+// - Filter-flipping mutations: when a mutation changes a column that the
+//   watch's `filterBy` references, the watch refetches automatically and
+//   the row appears / disappears from `data` to match. Works in both
+//   directions (a row newly matching the filter is pulled in).
+// - Rows created via `Model.create(...)` are not auto-added — that path
+//   doesn't go through a tagged shell. Use `useInvalidateKeys()` or
+//   `useModel(M).build(...)` + `.save()` for created rows.
 function TodoList({ userId }: { userId: number }) {
   const { data, isLoading } = useModel(Todo).filterBy({ userId }).watch({
     keys: ['todos', `todos-user:${userId}`],
@@ -130,7 +150,7 @@ invalidate(['todos', `todos-user:${id}`]);
 ```ts
 import type {
   ReactiveModelQuery,  // the full query builder surface
-  PendingResult,       // { fetch(): AsyncResult<T>; watch(): WatchResult<T> }
+  PendingResult,       // { fetch(): AsyncResult<T>; watch(): WatchResult<T>; run(): Promise<T> }
   AsyncResult,         // { data: T; isLoading: boolean; error: Error | undefined }
   WatchResult,         // { data: T; isLoading: boolean; isRefetching: boolean; error: Error | undefined }
   ModelInstanceType,   // extract instance type from a Model class
@@ -142,7 +162,8 @@ import type {
 
 - One `Store` per Provider, owning an identity map keyed by `tableName[pk]`.
 - `useModel` materialises rows into reactive Proxy shells; the same row across queries returns `===` the same shell within a Provider.
-- Mutations (assign / save / delete) emit per-instance to subscribed components AND broadcast on the row key so watches rerender.
+- `.fetch()` / `.watch()` / `.run()` all funnel through the same `adopt` path — every fetched instance becomes a tagged shell that publishes on mutation.
+- Mutations (`update` / `save` / `delete` / `increment` / `decrement`) emit per-instance to subscribed components AND broadcast on the row key so watches rerender. They also broadcast `col:<table>:<column>` for each column whose persistent value actually changes, so collection watches whose `filterBy` references those columns refetch (membership flips).
 - Watch result sets are refcounted; rows are evicted on the last unmount.
 - Provider unmount disposes the Store; subsequent broadcasts are silent.
 
@@ -150,7 +171,7 @@ import type {
 
 - No SSR / Next.js adapter (deferred to a separate package).
 - No Suspense integration.
-- No optimistic insertion of newly saved rows into watched arrays — use `useInvalidateKeys`.
+- Rows newly created via the static `Model.create(...)` (which doesn't go through a tagged shell) are not auto-added to watched arrays — use `useInvalidateKeys`, or use `useModel(M).build(...)` + `.save()` so the create round-trips through a shell.
 - No interval / background polling.
 - Cross-Provider mutations are not propagated.
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next-model/react",
-  "version": "1.1.6",
+  "version": "1.1.7-dev.0",
   "description": "React reactivity bindings for @next-model/core — Provider-scoped identity map, reactive instance shells, watch + invalidation hooks.",
   "author": "Tamino Martinius <dev@zaku.eu>",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next-model/react",
-  "version": "1.1.7-dev.0",
+  "version": "1.1.7-dev.1",
   "description": "React reactivity bindings for @next-model/core — Provider-scoped identity map, reactive instance shells, watch + invalidation hooks.",
   "author": "Tamino Martinius <dev@zaku.eu>",
   "license": "MIT",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next-model/react",
-  "version": "1.1.7-dev.1",
+  "version": "1.1.6",
   "description": "React reactivity bindings for @next-model/core — Provider-scoped identity map, reactive instance shells, watch + invalidation hooks.",
   "author": "Tamino Martinius <dev@zaku.eu>",
   "license": "MIT",

--- a/packages/react/src/ReactiveInstance.ts
+++ b/packages/react/src/ReactiveInstance.ts
@@ -23,11 +23,8 @@ const proxies = new WeakMap<object, object>();
 function mutatedColumns(prop: string, args: unknown[], target: unknown): string[] {
   if (prop === 'update' && args[0] && typeof args[0] === 'object') {
     const patch = args[0] as Record<string, unknown>;
-    const persistent =
-      ((target as { persistentProps?: Record<string, unknown> }).persistentProps ?? {}) as Record<
-        string,
-        unknown
-      >;
+    const persistent = ((target as { persistentProps?: Record<string, unknown> }).persistentProps ??
+      {}) as Record<string, unknown>;
     return Object.keys(patch).filter((k) => persistent[k] !== patch[k]);
   }
   if (prop === 'save') {

--- a/packages/react/src/ReactiveInstance.ts
+++ b/packages/react/src/ReactiveInstance.ts
@@ -1,7 +1,44 @@
 import type { Dict } from '@next-model/core';
 import { emitterFor, linkEmitter, storeFor } from './instanceState.js';
+import { columnKey } from './pkKey.js';
 
 const proxies = new WeakMap<object, object>();
+
+/**
+ * Compute the column names whose persistent value the in-flight mutation
+ * is about to change. Used to publish `columnKey(...)` so collection
+ * watches that filter on any of those columns can refetch (the row's
+ * membership in their result may have flipped).
+ *
+ * - `update(patch)`: diff `patch` against `persistentProps` so we only
+ *   broadcast columns whose value actually changes.
+ * - `save()`: read `changedProps` keys — the diff staged by prior
+ *   `assign(...)` or setter calls.
+ * - `increment(col)` / `decrement(col)`: the arg names the column.
+ *
+ * `assign` / `revertChange*` don't persist, `reload` doesn't know what
+ * changed, and `delete` is handled separately by `store.drop()` plus
+ * `publishRow`'s `!stillAlive` branch — all return `[]` here.
+ */
+function mutatedColumns(prop: string, args: unknown[], target: unknown): string[] {
+  if (prop === 'update' && args[0] && typeof args[0] === 'object') {
+    const patch = args[0] as Record<string, unknown>;
+    const persistent =
+      ((target as { persistentProps?: Record<string, unknown> }).persistentProps ?? {}) as Record<
+        string,
+        unknown
+      >;
+    return Object.keys(patch).filter((k) => persistent[k] !== patch[k]);
+  }
+  if (prop === 'save') {
+    const changed = (target as { changedProps?: Record<string, unknown> }).changedProps ?? {};
+    return Object.keys(changed);
+  }
+  if (prop === 'increment' || prop === 'decrement') {
+    return typeof args[0] === 'string' ? [args[0] as string] : [];
+  }
+  return [];
+}
 /**
  * Tracks resettable shells (form drafts created via `useModel(M).build(...)`).
  * They must not be inserted into the Store's identity map on save —
@@ -61,6 +98,10 @@ export function wrapInstance<T extends object>(
           // Capture keys before calling the method — delete() clears target.keys to undefined.
           const keysBefore = (target as { keys?: Record<string, unknown> }).keys;
           const tableName = ((target as object).constructor as { tableName?: string }).tableName;
+          // Compute the columns the mutation will change BEFORE running it
+          // — `save()` clears `changedProps`, and `update(patch)` needs the
+          // pre-mutation `persistentProps` to compute the diff.
+          const changedCols = mutatedColumns(prop, args, target);
           const result = (value as (...a: unknown[]) => unknown).apply(target, args);
           if (result && typeof (result as Promise<unknown>).then === 'function') {
             return (result as Promise<unknown>).then(
@@ -82,6 +123,14 @@ export function wrapInstance<T extends object>(
                       store.softRegister(tableName, keys, proxy as object);
                     }
                     store.publishRow(tableName, keys);
+                  }
+                  // Publish per-column keys for any actually-changed columns
+                  // so collection watches whose `filterBy` references those
+                  // columns refetch (membership may have flipped).
+                  if (tableName) {
+                    for (const col of changedCols) {
+                      store.publish(columnKey(tableName, col));
+                    }
                   }
                 }
                 return r;

--- a/packages/react/src/ReactiveQuery.ts
+++ b/packages/react/src/ReactiveQuery.ts
@@ -32,11 +32,20 @@ export interface QueryPlan {
 
 /**
  * A pending query that has not yet invoked a React hook.
- * Call `.fetch()` for a one-shot async result or `.watch()` for a live subscription.
+ *
+ * - `.fetch()` invokes `useAsyncTerminal` — a one-shot hook for render.
+ * - `.watch()` invokes `useWatch` — a live subscription, also a hook.
+ * - `.run()` is an imperative escape hatch: it returns a `Promise<T>` whose
+ *   instances are store-tagged reactive shells. Safe to call from
+ *   event handlers, mutation callbacks, or any non-render async code.
+ *   Subsequent `.update()` / `.delete()` calls on the returned shell
+ *   auto-publish the row key so existing watches refire without any
+ *   manual `invalidateKeys` plumbing.
  */
 export interface PendingResult<T> {
   fetch(): AsyncResult<T>;
   watch(options?: { keys?: (string | symbol)[] }): WatchResult<T>;
+  run(): Promise<T>;
 }
 
 /**

--- a/packages/react/src/__tests__/autoInvalidateFilterColumns.spec.tsx
+++ b/packages/react/src/__tests__/autoInvalidateFilterColumns.spec.tsx
@@ -12,40 +12,34 @@ beforeEach(async () => {
 describe('collection watches auto-refetch on filter-column mutations', () => {
   it('shell.update() that flips a filtered column drops the row from the watch', async () => {
     await Todo.create({ title: 'open', done: false });
-    const closed = (await Todo.create({ title: 'open-too', done: false })) as { id: number };
+    const closed = await Todo.create({ title: 'open-too', done: false });
 
     const { result } = renderHook(
       () => {
-        const ops = useModel(Todo as any) as any;
+        const ops = useModel(Todo);
         const watch = ops.filterBy({ done: false }).all().watch();
         return { ops, watch };
       },
       { wrapper: wrapWithProvider },
     );
     await waitFor(() => expect(result.current.watch.isLoading).toBe(false));
-    expect((result.current.watch.data as unknown[]).length).toBe(2);
+    expect(result.current.watch.data).toHaveLength(2);
 
-    const row = (await act(() => result.current.ops.find(closed.id).run())) as {
-      update: (p: object) => Promise<unknown>;
-    };
-    await act(() => row.update({ done: true }));
+    const row = await act(() => result.current.ops.find(closed.id).run());
+    await act(() => row!.update({ done: true }));
 
-    await waitFor(() => expect((result.current.watch.data as unknown[]).length).toBe(1));
-    expect(
-      (result.current.watch.data as Array<{ id: number }>).find((r) => r.id === closed.id),
-    ).toBeUndefined();
+    await waitFor(() => expect(result.current.watch.data).toHaveLength(1));
+    expect(result.current.watch.data.find((r) => r.id === closed.id)).toBeUndefined();
   });
 
   it('shell.update() that flips a $null filter brings a previously-hidden row INTO the watch', async () => {
     // Seed two rows: one matching the $null filter, one not.
     await Todo.create({ title: 'visible', done: false });
-    const hidden = (await Todo.create({ title: 'archived', done: false, userId: 99 })) as {
-      id: number;
-    };
+    const hidden = await Todo.create({ title: 'archived', done: false, userId: 99 });
 
     const { result } = renderHook(
       () => {
-        const ops = useModel(Todo as any) as any;
+        const ops = useModel(Todo);
         // userId is nullable; treat "userId IS NULL" as the visibility filter.
         const watch = ops.filterBy({ $null: 'userId' }).all().watch();
         return { ops, watch };
@@ -53,22 +47,20 @@ describe('collection watches auto-refetch on filter-column mutations', () => {
       { wrapper: wrapWithProvider },
     );
     await waitFor(() => expect(result.current.watch.isLoading).toBe(false));
-    expect((result.current.watch.data as unknown[]).length).toBe(1);
+    expect(result.current.watch.data).toHaveLength(1);
 
-    const row = (await act(() => result.current.ops.find(hidden.id).run())) as {
-      update: (p: object) => Promise<unknown>;
-    };
-    await act(() => row.update({ userId: null }));
+    const row = await act(() => result.current.ops.find(hidden.id).run());
+    await act(() => row!.update({ userId: null }));
 
-    await waitFor(() => expect((result.current.watch.data as unknown[]).length).toBe(2));
+    await waitFor(() => expect(result.current.watch.data).toHaveLength(2));
   });
 
   it('shell.update() on a column NOT named in any filter does not refetch the collection', async () => {
-    const a = (await Todo.create({ title: 'old', done: false })) as { id: number };
+    const a = await Todo.create({ title: 'old', done: false });
 
     const { result } = renderHook(
       () => {
-        const ops = useModel(Todo as any) as any;
+        const ops = useModel(Todo);
         // Filter is on `done`; we'll update only `title`.
         const watch = ops.filterBy({ done: false }).all().watch();
         return { ops, watch };
@@ -76,17 +68,14 @@ describe('collection watches auto-refetch on filter-column mutations', () => {
       { wrapper: wrapWithProvider },
     );
     await waitFor(() => expect(result.current.watch.isLoading).toBe(false));
-    const before = result.current.watch.data;
+    const beforeLength = result.current.watch.data.length;
 
-    const row = (await act(() => result.current.ops.find(a.id).run())) as {
-      update: (p: object) => Promise<unknown>;
-    };
-    await act(() => row.update({ title: 'new' }));
+    const row = await act(() => result.current.ops.find(a.id).run());
+    await act(() => row!.update({ title: 'new' }));
 
     // Row still in result, just with its updated title visible through the shell.
-    expect((result.current.watch.data as Array<{ id: number; title: string }>).length).toBe(1);
-    expect((result.current.watch.data as Array<{ title: string }>)[0]!.title).toBe('new');
-    // No row added/removed.
-    expect((result.current.watch.data as unknown[]).length).toBe((before as unknown[]).length);
+    expect(result.current.watch.data).toHaveLength(1);
+    expect(result.current.watch.data[0]!.title).toBe('new');
+    expect(result.current.watch.data).toHaveLength(beforeLength);
   });
 });

--- a/packages/react/src/__tests__/autoInvalidateFilterColumns.spec.tsx
+++ b/packages/react/src/__tests__/autoInvalidateFilterColumns.spec.tsx
@@ -87,8 +87,6 @@ describe('collection watches auto-refetch on filter-column mutations', () => {
     expect((result.current.watch.data as Array<{ id: number; title: string }>).length).toBe(1);
     expect((result.current.watch.data as Array<{ title: string }>)[0]!.title).toBe('new');
     // No row added/removed.
-    expect((result.current.watch.data as unknown[]).length).toBe(
-      (before as unknown[]).length,
-    );
+    expect((result.current.watch.data as unknown[]).length).toBe((before as unknown[]).length);
   });
 });

--- a/packages/react/src/__tests__/autoInvalidateFilterColumns.spec.tsx
+++ b/packages/react/src/__tests__/autoInvalidateFilterColumns.spec.tsx
@@ -1,0 +1,94 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useModel } from '../useModel.js';
+import { makeFixtures, wrapWithProvider } from './helpers.js';
+
+const { Todo, reset } = makeFixtures();
+
+beforeEach(async () => {
+  await reset();
+});
+
+describe('collection watches auto-refetch on filter-column mutations', () => {
+  it('shell.update() that flips a filtered column drops the row from the watch', async () => {
+    await Todo.create({ title: 'open', done: false });
+    const closed = (await Todo.create({ title: 'open-too', done: false })) as { id: number };
+
+    const { result } = renderHook(
+      () => {
+        const ops = useModel(Todo as any) as any;
+        const watch = ops.filterBy({ done: false }).all().watch();
+        return { ops, watch };
+      },
+      { wrapper: wrapWithProvider },
+    );
+    await waitFor(() => expect(result.current.watch.isLoading).toBe(false));
+    expect((result.current.watch.data as unknown[]).length).toBe(2);
+
+    const row = (await act(() => result.current.ops.find(closed.id).run())) as {
+      update: (p: object) => Promise<unknown>;
+    };
+    await act(() => row.update({ done: true }));
+
+    await waitFor(() => expect((result.current.watch.data as unknown[]).length).toBe(1));
+    expect(
+      (result.current.watch.data as Array<{ id: number }>).find((r) => r.id === closed.id),
+    ).toBeUndefined();
+  });
+
+  it('shell.update() that flips a $null filter brings a previously-hidden row INTO the watch', async () => {
+    // Seed two rows: one matching the $null filter, one not.
+    await Todo.create({ title: 'visible', done: false });
+    const hidden = (await Todo.create({ title: 'archived', done: false, userId: 99 })) as {
+      id: number;
+    };
+
+    const { result } = renderHook(
+      () => {
+        const ops = useModel(Todo as any) as any;
+        // userId is nullable; treat "userId IS NULL" as the visibility filter.
+        const watch = ops.filterBy({ $null: 'userId' }).all().watch();
+        return { ops, watch };
+      },
+      { wrapper: wrapWithProvider },
+    );
+    await waitFor(() => expect(result.current.watch.isLoading).toBe(false));
+    expect((result.current.watch.data as unknown[]).length).toBe(1);
+
+    const row = (await act(() => result.current.ops.find(hidden.id).run())) as {
+      update: (p: object) => Promise<unknown>;
+    };
+    await act(() => row.update({ userId: null }));
+
+    await waitFor(() => expect((result.current.watch.data as unknown[]).length).toBe(2));
+  });
+
+  it('shell.update() on a column NOT named in any filter does not refetch the collection', async () => {
+    const a = (await Todo.create({ title: 'old', done: false })) as { id: number };
+
+    const { result } = renderHook(
+      () => {
+        const ops = useModel(Todo as any) as any;
+        // Filter is on `done`; we'll update only `title`.
+        const watch = ops.filterBy({ done: false }).all().watch();
+        return { ops, watch };
+      },
+      { wrapper: wrapWithProvider },
+    );
+    await waitFor(() => expect(result.current.watch.isLoading).toBe(false));
+    const before = result.current.watch.data;
+
+    const row = (await act(() => result.current.ops.find(a.id).run())) as {
+      update: (p: object) => Promise<unknown>;
+    };
+    await act(() => row.update({ title: 'new' }));
+
+    // Row still in result, just with its updated title visible through the shell.
+    expect((result.current.watch.data as Array<{ id: number; title: string }>).length).toBe(1);
+    expect((result.current.watch.data as Array<{ title: string }>)[0]!.title).toBe('new');
+    // No row added/removed.
+    expect((result.current.watch.data as unknown[]).length).toBe(
+      (before as unknown[]).length,
+    );
+  });
+});

--- a/packages/react/src/__tests__/filterColumns.spec.ts
+++ b/packages/react/src/__tests__/filterColumns.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { extractFilterColumns, filterColumnsOf } from '../filterColumns.js';
+import type { QueryPlan } from '../ReactiveQuery.js';
+
+const plan = (steps: QueryPlan['steps']): QueryPlan => ({
+  ModelClass: { tableName: 't' },
+  steps,
+});
+
+describe('extractFilterColumns', () => {
+  it('adds plain column predicates', () => {
+    const cols = new Set<string>();
+    extractFilterColumns({ projectId: 'p1', state: 'open' }, cols);
+    expect([...cols].sort()).toEqual(['projectId', 'state']);
+  });
+
+  it('handles $null / $notNull keyed by a column name string', () => {
+    const cols = new Set<string>();
+    extractFilterColumns({ $null: 'archivedAt' }, cols);
+    extractFilterColumns({ $notNull: 'closedAt' }, cols);
+    expect([...cols].sort()).toEqual(['archivedAt', 'closedAt']);
+  });
+
+  it('handles $in / $notIn / $between keyed by column → values', () => {
+    const cols = new Set<string>();
+    extractFilterColumns({ $in: { id: [1, 2] } }, cols);
+    extractFilterColumns({ $notIn: { state: ['done'] } }, cols);
+    extractFilterColumns({ $between: { age: [10, 20] } }, cols);
+    expect([...cols].sort()).toEqual(['age', 'id', 'state']);
+  });
+
+  it('recurses into $and / $or arrays', () => {
+    const cols = new Set<string>();
+    extractFilterColumns({ $and: [{ a: 1 }, { $or: [{ b: 2 }, { c: 3 }] }] }, cols);
+    expect([...cols].sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('recurses into $not', () => {
+    const cols = new Set<string>();
+    extractFilterColumns({ $not: { x: 1 } }, cols);
+    expect([...cols]).toEqual(['x']);
+  });
+
+  it('skips unknown $-operators without throwing', () => {
+    const cols = new Set<string>();
+    extractFilterColumns({ $unknown: 'foo', name: 'n' }, cols);
+    expect([...cols]).toEqual(['name']);
+  });
+
+  it('ignores non-objects', () => {
+    const cols = new Set<string>();
+    extractFilterColumns(null, cols);
+    extractFilterColumns(undefined, cols);
+    extractFilterColumns(42, cols);
+    expect(cols.size).toBe(0);
+  });
+});
+
+describe('filterColumnsOf', () => {
+  it('returns empty for a plan with no filters', () => {
+    expect(filterColumnsOf(plan([]))).toEqual(new Set());
+  });
+
+  it('walks every filterBy step', () => {
+    const cols = filterColumnsOf(
+      plan([
+        { method: 'filterBy', args: [{ projectId: 'p1' }] },
+        { method: 'filterBy', args: [{ $null: 'archivedAt' }] },
+      ]),
+    );
+    expect([...cols].sort()).toEqual(['archivedAt', 'projectId']);
+  });
+
+  it('includes whereMissing column names', () => {
+    const cols = filterColumnsOf(
+      plan([{ method: 'whereMissing', args: ['parentId'] }]),
+    );
+    expect([...cols]).toEqual(['parentId']);
+  });
+
+  it('ignores non-filter chain methods (orderBy, limit, etc.)', () => {
+    const cols = filterColumnsOf(
+      plan([
+        { method: 'orderBy', args: [{ key: 'createdAt', dir: 1 }] },
+        { method: 'limit', args: [10] },
+      ]),
+    );
+    expect(cols.size).toBe(0);
+  });
+});

--- a/packages/react/src/__tests__/filterColumns.spec.ts
+++ b/packages/react/src/__tests__/filterColumns.spec.ts
@@ -72,9 +72,7 @@ describe('filterColumnsOf', () => {
   });
 
   it('includes whereMissing column names', () => {
-    const cols = filterColumnsOf(
-      plan([{ method: 'whereMissing', args: ['parentId'] }]),
-    );
+    const cols = filterColumnsOf(plan([{ method: 'whereMissing', args: ['parentId'] }]));
     expect([...cols]).toEqual(['parentId']);
   });
 

--- a/packages/react/src/__tests__/useModelRun.spec.tsx
+++ b/packages/react/src/__tests__/useModelRun.spec.tsx
@@ -14,99 +14,84 @@ describe('useModel(M).<terminal>.run()', () => {
     await Todo.create({ title: 'a', done: false });
     await Todo.create({ title: 'b', done: true });
 
-    const { result } = renderHook(() => useModel(Todo as any), {
+    const { result } = renderHook(() => useModel(Todo), {
       wrapper: wrapWithProvider,
     });
 
-    const rows = await act(() => (result.current as any).all().run());
-    expect(Array.isArray(rows)).toBe(true);
+    const rows = await act(() => result.current.all().run());
     expect(rows).toHaveLength(2);
-    // Tagged shells are Proxy-wrapped; their `update`/`delete` are functions.
-    expect(typeof (rows as object[])[0]).toBe('object');
-    expect(typeof ((rows as any)[0] as { update: unknown }).update).toBe('function');
+    // Tagged shells expose `.update` / `.delete` — verifies the proxy wrap.
+    expect(typeof rows[0]!.update).toBe('function');
+    expect(typeof rows[0]!.delete).toBe('function');
   });
 
   it('first().run() returns a tagged shell or undefined', async () => {
-    const { result } = renderHook(() => useModel(Todo as any), {
+    const { result } = renderHook(() => useModel(Todo), {
       wrapper: wrapWithProvider,
     });
 
-    expect(await act(() => (result.current as any).first().run())).toBeUndefined();
+    expect(await act(() => result.current.first().run())).toBeUndefined();
 
     await Todo.create({ title: 'a', done: false });
-    const row = (await act(() => (result.current as any).first().run())) as
-      | { title: string; update: (p: object) => Promise<unknown> }
-      | undefined;
+    const row = await act(() => result.current.first().run());
     expect(row).toBeDefined();
     expect(row?.title).toBe('a');
   });
 
   it('find(pk).run() returns the tagged row, or undefined when missing', async () => {
-    const created = (await Todo.create({ title: 'a', done: false })) as {
-      id: number;
-    };
+    const created = await Todo.create({ title: 'a', done: false });
 
-    const { result } = renderHook(() => useModel(Todo as any), {
+    const { result } = renderHook(() => useModel(Todo), {
       wrapper: wrapWithProvider,
     });
 
-    const row = (await act(() => (result.current as any).find(created.id).run())) as
-      | { id: number; title: string }
-      | undefined;
+    const row = await act(() => result.current.find(created.id).run());
     expect(row?.id).toBe(created.id);
     expect(row?.title).toBe('a');
 
-    expect(await act(() => (result.current as any).find(99999).run())).toBeUndefined();
+    expect(await act(() => result.current.find(99999).run())).toBeUndefined();
   });
 
   it('shell mutation via .update() refires a sibling .watch() without manual invalidate', async () => {
-    const created = (await Todo.create({ title: 'old', done: false })) as { id: number };
+    const created = await Todo.create({ title: 'old', done: false });
 
     // Both hooks mounted under one Provider so they share a Store.
     const { result } = renderHook(
       () => {
-        const ops = useModel(Todo as any) as any;
+        const ops = useModel(Todo);
         const watch = ops.filterBy({ id: created.id }).first().watch();
         return { ops, watch };
       },
       { wrapper: wrapWithProvider },
     );
     await waitFor(() => expect(result.current.watch.isLoading).toBe(false));
-    expect((result.current.watch.data as { title: string } | undefined)?.title).toBe('old');
+    expect(result.current.watch.data?.title).toBe('old');
 
-    const row = (await act(() => result.current.ops.find(created.id).run())) as {
-      update: (p: object) => Promise<unknown>;
-    };
-    await act(() => row.update({ title: 'new' }));
+    const row = await act(() => result.current.ops.find(created.id).run());
+    await act(() => row!.update({ title: 'new' }));
 
-    await waitFor(() =>
-      expect((result.current.watch.data as { title: string } | undefined)?.title).toBe('new'),
-    );
+    await waitFor(() => expect(result.current.watch.data?.title).toBe('new'));
   });
 
   it('shell .delete() drops the row and refires a sibling .all().watch()', async () => {
-    const created = (await Todo.create({ title: 'a', done: false })) as { id: number };
+    const created = await Todo.create({ title: 'a', done: false });
     await Todo.create({ title: 'b', done: false });
 
     const { result } = renderHook(
       () => {
-        const ops = useModel(Todo as any) as any;
+        const ops = useModel(Todo);
         const watch = ops.all().watch();
         return { ops, watch };
       },
       { wrapper: wrapWithProvider },
     );
     await waitFor(() => expect(result.current.watch.isLoading).toBe(false));
-    expect((result.current.watch.data as unknown[]).length).toBe(2);
+    expect(result.current.watch.data).toHaveLength(2);
 
-    const row = (await act(() => result.current.ops.find(created.id).run())) as {
-      delete: () => Promise<unknown>;
-    };
-    await act(() => row.delete());
+    const row = await act(() => result.current.ops.find(created.id).run());
+    await act(() => row!.delete());
 
-    await waitFor(() => expect((result.current.watch.data as unknown[]).length).toBe(1));
-    expect(
-      (result.current.watch.data as Array<{ id: number }>).find((r) => r.id === created.id),
-    ).toBeUndefined();
+    await waitFor(() => expect(result.current.watch.data).toHaveLength(1));
+    expect(result.current.watch.data.find((r) => r.id === created.id)).toBeUndefined();
   });
 });

--- a/packages/react/src/__tests__/useModelRun.spec.tsx
+++ b/packages/react/src/__tests__/useModelRun.spec.tsx
@@ -1,0 +1,112 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useModel } from '../useModel.js';
+import { makeFixtures, wrapWithProvider } from './helpers.js';
+
+const { Todo, reset } = makeFixtures();
+
+beforeEach(async () => {
+  await reset();
+});
+
+describe('useModel(M).<terminal>.run()', () => {
+  it('all().run() returns tagged shells for every row', async () => {
+    await Todo.create({ title: 'a', done: false });
+    await Todo.create({ title: 'b', done: true });
+
+    const { result } = renderHook(() => useModel(Todo as any), {
+      wrapper: wrapWithProvider,
+    });
+
+    const rows = await act(() => (result.current as any).all().run());
+    expect(Array.isArray(rows)).toBe(true);
+    expect(rows).toHaveLength(2);
+    // Tagged shells are Proxy-wrapped; their `update`/`delete` are functions.
+    expect(typeof (rows as object[])[0]).toBe('object');
+    expect(typeof ((rows as any)[0] as { update: unknown }).update).toBe('function');
+  });
+
+  it('first().run() returns a tagged shell or undefined', async () => {
+    const { result } = renderHook(() => useModel(Todo as any), {
+      wrapper: wrapWithProvider,
+    });
+
+    expect(await act(() => (result.current as any).first().run())).toBeUndefined();
+
+    await Todo.create({ title: 'a', done: false });
+    const row = (await act(() => (result.current as any).first().run())) as
+      | { title: string; update: (p: object) => Promise<unknown> }
+      | undefined;
+    expect(row).toBeDefined();
+    expect(row?.title).toBe('a');
+  });
+
+  it('find(pk).run() returns the tagged row, or undefined when missing', async () => {
+    const created = (await Todo.create({ title: 'a', done: false })) as {
+      id: number;
+    };
+
+    const { result } = renderHook(() => useModel(Todo as any), {
+      wrapper: wrapWithProvider,
+    });
+
+    const row = (await act(() => (result.current as any).find(created.id).run())) as
+      | { id: number; title: string }
+      | undefined;
+    expect(row?.id).toBe(created.id);
+    expect(row?.title).toBe('a');
+
+    expect(await act(() => (result.current as any).find(99999).run())).toBeUndefined();
+  });
+
+  it('shell mutation via .update() refires a sibling .watch() without manual invalidate', async () => {
+    const created = (await Todo.create({ title: 'old', done: false })) as { id: number };
+
+    // Both hooks mounted under one Provider so they share a Store.
+    const { result } = renderHook(
+      () => {
+        const ops = useModel(Todo as any) as any;
+        const watch = ops.filterBy({ id: created.id }).first().watch();
+        return { ops, watch };
+      },
+      { wrapper: wrapWithProvider },
+    );
+    await waitFor(() => expect(result.current.watch.isLoading).toBe(false));
+    expect((result.current.watch.data as { title: string } | undefined)?.title).toBe('old');
+
+    const row = (await act(() => result.current.ops.find(created.id).run())) as {
+      update: (p: object) => Promise<unknown>;
+    };
+    await act(() => row.update({ title: 'new' }));
+
+    await waitFor(() =>
+      expect((result.current.watch.data as { title: string } | undefined)?.title).toBe('new'),
+    );
+  });
+
+  it('shell .delete() drops the row and refires a sibling .all().watch()', async () => {
+    const created = (await Todo.create({ title: 'a', done: false })) as { id: number };
+    await Todo.create({ title: 'b', done: false });
+
+    const { result } = renderHook(
+      () => {
+        const ops = useModel(Todo as any) as any;
+        const watch = ops.all().watch();
+        return { ops, watch };
+      },
+      { wrapper: wrapWithProvider },
+    );
+    await waitFor(() => expect(result.current.watch.isLoading).toBe(false));
+    expect((result.current.watch.data as unknown[]).length).toBe(2);
+
+    const row = (await act(() => result.current.ops.find(created.id).run())) as {
+      delete: () => Promise<unknown>;
+    };
+    await act(() => row.delete());
+
+    await waitFor(() => expect((result.current.watch.data as unknown[]).length).toBe(1));
+    expect(
+      (result.current.watch.data as Array<{ id: number }>).find((r) => r.id === created.id),
+    ).toBeUndefined();
+  });
+});

--- a/packages/react/src/adoptInstance.ts
+++ b/packages/react/src/adoptInstance.ts
@@ -1,0 +1,48 @@
+import type { Dict } from '@next-model/core';
+import { tagStore } from './instanceState.js';
+import { wrapInstance } from './ReactiveInstance.js';
+import type { Store } from './Store.js';
+
+function keysOf(instance: object): Dict<unknown> {
+  return (instance as { keys?: Dict<unknown> }).keys ?? {};
+}
+
+function isModelInstance(x: unknown): x is object {
+  return Boolean(x && typeof x === 'object' && 'attributes' in (x as object));
+}
+
+/**
+ * Tag a freshly fetched raw instance with the store, wrap it in a reactive
+ * shell, and reconcile against any already-canonical shell in the store's
+ * identity map. Shared by `useAsyncTerminal`, `useWatch`, and `run()`.
+ *
+ * Mutations performed through the returned shell auto-publish the row's
+ * key via `ReactiveInstance`'s `BROADCAST_METHODS` wrapper.
+ */
+export function adopt(instance: object, tableName: string, store: Store): object {
+  tagStore(instance, store);
+  const shell = wrapInstance(instance);
+  const keys = keysOf(instance);
+  if (Object.keys(keys).length === 0) return shell;
+  const cached = store.acquire(tableName, keys);
+  if (cached) {
+    const freshAttrs = (instance as { persistentProps?: Record<string, unknown> }).persistentProps;
+    if (freshAttrs)
+      (cached as { persistentProps: Record<string, unknown> }).persistentProps = freshAttrs;
+    return cached;
+  }
+  store.softRegister(tableName, keys, shell);
+  return shell;
+}
+
+export function decorate(raw: unknown, tableName: string, store: Store): unknown {
+  if (Array.isArray(raw)) {
+    const out: object[] = [];
+    for (const row of raw) {
+      if (isModelInstance(row)) out.push(adopt(row, tableName, store));
+    }
+    return out;
+  }
+  if (isModelInstance(raw)) return adopt(raw, tableName, store);
+  return raw;
+}

--- a/packages/react/src/filterColumns.ts
+++ b/packages/react/src/filterColumns.ts
@@ -1,0 +1,62 @@
+import type { QueryPlan } from './ReactiveQuery.js';
+
+/**
+ * Walk a `filterBy` predicate (or any nested sub-filter from `$and` / `$or` /
+ * `$not`) and collect every column name it references. Used by `useWatch` to
+ * subscribe to per-column publishes — so a mutation that changes a column
+ * the watch filters on causes a refetch (membership may have flipped).
+ *
+ * Supported predicate shapes (matching `@next-model/core`'s filter DSL):
+ * - Plain column predicates: `{ projectId: 'p1' }` → adds `projectId`.
+ * - `$null` / `$notNull` over a column name string: `{ $null: 'archivedAt' }` → adds `archivedAt`.
+ * - `$in` / `$notIn` / `$between` keyed by column: `{ $in: { id: [1, 2] } }` → adds `id`.
+ * - `$and` / `$or` arrays: recurse into each child.
+ * - `$not` single child: recurse.
+ *
+ * Other `$`-prefixed operators are treated as scalars and ignored.
+ */
+export function extractFilterColumns(filter: unknown, columns: Set<string>): void {
+  if (!filter || typeof filter !== 'object') return;
+  for (const [k, v] of Object.entries(filter as Record<string, unknown>)) {
+    if (k === '$and' || k === '$or') {
+      if (Array.isArray(v)) {
+        for (const sub of v) extractFilterColumns(sub, columns);
+      }
+      continue;
+    }
+    if (k === '$not') {
+      extractFilterColumns(v, columns);
+      continue;
+    }
+    if (k === '$null' || k === '$notNull') {
+      if (typeof v === 'string') columns.add(v);
+      continue;
+    }
+    if (k === '$in' || k === '$notIn' || k === '$between') {
+      if (v && typeof v === 'object') {
+        for (const col of Object.keys(v as object)) columns.add(col);
+      }
+      continue;
+    }
+    if (!k.startsWith('$')) {
+      columns.add(k);
+    }
+  }
+}
+
+/**
+ * Collect every column name a query's `filterBy` (and `whereMissing`) chain
+ * references. Returns an empty set for queries that don't filter by any
+ * column (e.g., `useModel(M).all().watch(...)` on the whole table).
+ */
+export function filterColumnsOf(plan: QueryPlan): Set<string> {
+  const cols = new Set<string>();
+  for (const step of plan.steps) {
+    if (step.method === 'filterBy' && step.args.length > 0) {
+      extractFilterColumns(step.args[0], cols);
+    } else if (step.method === 'whereMissing' && typeof step.args[0] === 'string') {
+      cols.add(step.args[0] as string);
+    }
+  }
+  return cols;
+}

--- a/packages/react/src/pkKey.ts
+++ b/packages/react/src/pkKey.ts
@@ -9,3 +9,14 @@ export function pkKey(keys: Dict<unknown>): string {
 export function rowKey(tableName: string, keys: Dict<unknown>): string {
   return `row:${tableName}:${pkKey(keys)}`;
 }
+
+/**
+ * Key published when a mutation changes the value of `columnName` on any
+ * row of `tableName`. Collection watches whose `filterBy` predicate names
+ * this column subscribe to it so the watch refetches when membership may
+ * have flipped (a row matching the filter now no longer matches, or vice
+ * versa).
+ */
+export function columnKey(tableName: string, columnName: string): string {
+  return `col:${tableName}:${columnName}`;
+}

--- a/packages/react/src/useAsyncTerminal.ts
+++ b/packages/react/src/useAsyncTerminal.ts
@@ -1,10 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
-import { tagStore } from './instanceState.js';
+import { decorate } from './adoptInstance.js';
 import { useStore } from './Provider.js';
-import { wrapInstance } from './ReactiveInstance.js';
 import type { ReactiveQuery, TerminalKind } from './ReactiveQuery.js';
 import { runQuery } from './runQuery.js';
-import type { Store } from './Store.js';
 
 export interface AsyncResult<T> {
   data: T;
@@ -18,31 +16,13 @@ function initialData<T>(kind: TerminalKind): T {
   return (ARRAY_TERMINALS.has(kind) ? [] : undefined) as T;
 }
 
-function isModelInstance(x: unknown): x is object {
-  return Boolean(x && typeof x === 'object' && 'attributes' in (x as object));
-}
-
-function adopt(raw: unknown, store: Store): unknown {
-  if (Array.isArray(raw)) {
-    return raw.map((row) => {
-      if (!isModelInstance(row)) return row;
-      tagStore(row, store);
-      return wrapInstance(row);
-    });
-  }
-  if (isModelInstance(raw)) {
-    tagStore(raw, store);
-    return wrapInstance(raw);
-  }
-  return raw;
-}
-
 export function useAsyncTerminal<T>(
   query: ReactiveQuery<{ tableName: string }>,
   terminal: TerminalKind,
   terminalArgs: unknown[],
 ): AsyncResult<T> {
   const store = useStore();
+  const tableName = query.plan.ModelClass.tableName;
   const queryKey = query.hash(terminal, terminalArgs);
 
   const [state, setState] = useState<AsyncResult<T>>(() => ({
@@ -62,7 +42,7 @@ export function useAsyncTerminal<T>(
       (raw) => {
         if (inflightRef.current !== id) return;
         hasFetchedRef.current = true;
-        setState({ data: adopt(raw, store) as T, isLoading: false, error: undefined });
+        setState({ data: decorate(raw, tableName, store) as T, isLoading: false, error: undefined });
       },
       (error: unknown) => {
         if (inflightRef.current !== id) return;

--- a/packages/react/src/useAsyncTerminal.ts
+++ b/packages/react/src/useAsyncTerminal.ts
@@ -42,7 +42,11 @@ export function useAsyncTerminal<T>(
       (raw) => {
         if (inflightRef.current !== id) return;
         hasFetchedRef.current = true;
-        setState({ data: decorate(raw, tableName, store) as T, isLoading: false, error: undefined });
+        setState({
+          data: decorate(raw, tableName, store) as T,
+          isLoading: false,
+          error: undefined,
+        });
       },
       (error: unknown) => {
         if (inflightRef.current !== id) return;

--- a/packages/react/src/useModel.ts
+++ b/packages/react/src/useModel.ts
@@ -10,8 +10,8 @@ import {
   ReactiveQuery,
   type TerminalKind,
 } from './ReactiveQuery.js';
-import type { Store } from './Store.js';
 import { runQuery } from './runQuery.js';
+import type { Store } from './Store.js';
 import { useAsyncTerminal } from './useAsyncTerminal.js';
 import { useWatch } from './useWatch.js';
 

--- a/packages/react/src/useModel.ts
+++ b/packages/react/src/useModel.ts
@@ -1,4 +1,5 @@
 import { useMemo, useRef, useSyncExternalStore } from 'react';
+import { decorate } from './adoptInstance.js';
 import { emitterFor, tagStore } from './instanceState.js';
 import { useStore } from './Provider.js';
 import { wrapInstance } from './ReactiveInstance.js';
@@ -9,6 +10,8 @@ import {
   ReactiveQuery,
   type TerminalKind,
 } from './ReactiveQuery.js';
+import type { Store } from './Store.js';
+import { runQuery } from './runQuery.js';
 import { useAsyncTerminal } from './useAsyncTerminal.js';
 import { useWatch } from './useWatch.js';
 
@@ -44,10 +47,14 @@ const CHAIN_METHODS = [
 class HookQuery<M extends { tableName: string }> extends ReactiveQuery<M> {}
 
 /**
- * Attaches `.fetch()` and `.watch()` to a query.
+ * Attaches `.fetch()`, `.watch()`, and `.run()` to a query.
  * Uses the plan's `terminal`/`terminalArgs` if set, defaulting to `'all'`.
+ *
+ * `.run()` captures the store from the enclosing `useModel(M)` call so
+ * the returned promise can be awaited in async event handlers without
+ * any hook-rules issues; the resolved instances are store-tagged shells.
  */
-function attachFetchAndWatch(query: HookQuery<{ tableName: string }>) {
+function attachFetchAndWatch(query: HookQuery<{ tableName: string }>, store: Store) {
   Object.defineProperty(query, 'fetch', {
     configurable: true,
     value: () => {
@@ -66,6 +73,15 @@ function attachFetchAndWatch(query: HookQuery<{ tableName: string }>) {
       return useWatch(query, terminal, terminalArgs, options);
     },
   });
+  Object.defineProperty(query, 'run', {
+    configurable: true,
+    value: async () => {
+      const terminal = query.plan.terminal ?? 'all';
+      const terminalArgs = query.plan.terminalArgs ?? [];
+      const raw = await runQuery(query, terminal, terminalArgs);
+      return decorate(raw, query.plan.ModelClass.tableName, store);
+    },
+  });
 }
 
 /**
@@ -73,7 +89,7 @@ function attachFetchAndWatch(query: HookQuery<{ tableName: string }>) {
  * Each terminal method returns a NEW HookQuery with the terminal recorded in the plan,
  * and with `.fetch()` / `.watch()` attached — no hook is invoked yet.
  */
-function attachPendingTerminals(query: HookQuery<{ tableName: string }>) {
+function attachPendingTerminals(query: HookQuery<{ tableName: string }>, store: Store) {
   for (const [name, kind] of PENDING_TERMINALS) {
     Object.defineProperty(query, name, {
       configurable: true,
@@ -84,7 +100,7 @@ function attachPendingTerminals(query: HookQuery<{ tableName: string }>) {
           terminal: kind,
           terminalArgs: args,
         });
-        attachFetchAndWatch(next);
+        attachFetchAndWatch(next, store);
         return next;
       },
     });
@@ -95,7 +111,7 @@ function attachPendingTerminals(query: HookQuery<{ tableName: string }>) {
  * Attaches chain methods (filterBy, where, etc.) to a query.
  * Each chain method returns a new query with the full surface re-attached.
  */
-function attachChain(query: HookQuery<{ tableName: string }>) {
+function attachChain(query: HookQuery<{ tableName: string }>, store: Store) {
   for (const m of CHAIN_METHODS) {
     const original = (query as any)[m].bind(query);
     Object.defineProperty(query, m, {
@@ -103,9 +119,9 @@ function attachChain(query: HookQuery<{ tableName: string }>) {
       value: (...args: unknown[]) => {
         const next = original(...args) as HookQuery<{ tableName: string }>;
         Object.setPrototypeOf(next, HookQuery.prototype);
-        attachPendingTerminals(next);
-        attachChain(next);
-        attachFetchAndWatch(next);
+        attachPendingTerminals(next, store);
+        attachChain(next, store);
+        attachFetchAndWatch(next, store);
         return next;
       },
     });
@@ -139,9 +155,9 @@ export function useModel<M extends { tableName: string; build: (props?: any) => 
     },
   });
 
-  attachPendingTerminals(query);
-  attachChain(query);
-  attachFetchAndWatch(query);
+  attachPendingTerminals(query, store);
+  attachChain(query, store);
+  attachFetchAndWatch(query, store);
 
   return query as unknown as ReactiveModelQuery<ModelInstanceType<M>, ModelCreatePropsType<M>>;
 }

--- a/packages/react/src/useWatch.ts
+++ b/packages/react/src/useWatch.ts
@@ -1,8 +1,9 @@
 import type { Dict } from '@next-model/core';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { decorate } from './adoptInstance.js';
+import { filterColumnsOf } from './filterColumns.js';
 import { useStore } from './Provider.js';
-import { rowKey } from './pkKey.js';
+import { columnKey, rowKey } from './pkKey.js';
 import type { ReactiveQuery, TerminalKind } from './ReactiveQuery.js';
 import { runQuery } from './runQuery.js';
 
@@ -142,6 +143,24 @@ export function useWatch<T>(
   useEffect(() => {
     if (!options.keys?.length) return;
     const offs = options.keys.map((k) => store.subscribe(k, () => fetch('refetch')));
+    return () => {
+      for (const off of offs) off();
+    };
+  }, [queryKey]);
+
+  // Effect 3: subscribe to the column keys named by the query's filterBy
+  // chain. When a row mutation changes any of those columns (publishes
+  // `col:<table>:<column>`), refetch so collection-membership flips
+  // surface — e.g. a row whose `archivedAt` was just set drops out of a
+  // `filterBy({ $null: 'archivedAt' })` watch.
+  const filterCols = useMemo(() => filterColumnsOf(query.plan), [queryKey]);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: queryKey encodes plan + filterCols depends on plan
+  useEffect(() => {
+    if (filterCols.size === 0) return;
+    const offs: Array<() => void> = [];
+    for (const col of filterCols) {
+      offs.push(store.subscribe(columnKey(tableName, col), () => fetch('refetch')));
+    }
     return () => {
       for (const off of offs) off();
     };

--- a/packages/react/src/useWatch.ts
+++ b/packages/react/src/useWatch.ts
@@ -1,5 +1,5 @@
 import type { Dict } from '@next-model/core';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { decorate } from './adoptInstance.js';
 import { filterColumnsOf } from './filterColumns.js';
 import { useStore } from './Provider.js';
@@ -152,10 +152,12 @@ export function useWatch<T>(
   // chain. When a row mutation changes any of those columns (publishes
   // `col:<table>:<column>`), refetch so collection-membership flips
   // surface — e.g. a row whose `archivedAt` was just set drops out of a
-  // `filterBy({ $null: 'archivedAt' })` watch.
-  const filterCols = useMemo(() => filterColumnsOf(query.plan), [queryKey]);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: queryKey encodes plan + filterCols depends on plan
+  // `filterBy({ $null: 'archivedAt' })` watch. `queryKey` already hashes
+  // `query.plan`, so re-running this effect on `queryKey` change is the
+  // right granularity.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: queryKey hashes query.plan
   useEffect(() => {
+    const filterCols = filterColumnsOf(query.plan);
     if (filterCols.size === 0) return;
     const offs: Array<() => void> = [];
     for (const col of filterCols) {

--- a/packages/react/src/useWatch.ts
+++ b/packages/react/src/useWatch.ts
@@ -1,12 +1,10 @@
 import type { Dict } from '@next-model/core';
 import { useEffect, useRef, useState } from 'react';
-import { tagStore } from './instanceState.js';
+import { decorate } from './adoptInstance.js';
 import { useStore } from './Provider.js';
 import { rowKey } from './pkKey.js';
-import { wrapInstance } from './ReactiveInstance.js';
 import type { ReactiveQuery, TerminalKind } from './ReactiveQuery.js';
 import { runQuery } from './runQuery.js';
-import type { Store } from './Store.js';
 
 export interface WatchResult<T> {
   data: T;
@@ -34,35 +32,8 @@ function isModelInstance(x: unknown): x is object {
   return Boolean(x && typeof x === 'object' && 'attributes' in (x as object));
 }
 
-function adopt(instance: object, tableName: string, store: Store): object {
-  tagStore(instance, store);
-  const shell = wrapInstance(instance);
-  const keys = keysOf(instance);
-  if (Object.keys(keys).length === 0) return shell; // unsaved — should not happen for watch results
-  const cached = store.acquire(tableName, keys);
-  if (cached) {
-    // Sync persistent attributes from the freshly-fetched instance into the
-    // canonical shell so that saves performed through any proxy are reflected here.
-    const freshAttrs = (instance as { persistentProps?: Record<string, unknown> }).persistentProps;
-    if (freshAttrs)
-      (cached as { persistentProps: Record<string, unknown> }).persistentProps = freshAttrs;
-    return cached;
-  }
-  store.softRegister(tableName, keys, shell);
-  return shell;
-}
-
-function decorate(raw: unknown, tableName: string, store: Store): unknown {
-  if (Array.isArray(raw)) {
-    const out: object[] = [];
-    for (const row of raw) {
-      if (isModelInstance(row)) out.push(adopt(row, tableName, store));
-    }
-    return out;
-  }
-  if (isModelInstance(raw)) return adopt(raw, tableName, store);
-  return raw;
-}
+// `adopt` and `decorate` live in `./adoptInstance.js` (shared with
+// `useAsyncTerminal` and `useModel`'s `.run()` terminal).
 
 export function useWatch<T>(
   query: ReactiveQuery<{ tableName: string }>,


### PR DESCRIPTION
## Summary

Closes the gap where mutating a row looked up via `Model.find(id)` outside an active watch silently dropped reactivity — the most intuitive path in user-land code was also the broken one.

Two related changes that compose:

### 1. `.run()` terminal on `PendingResult<T>` (commit 1)

`useModel(M).<terminal>().run()` returns a `Promise<T>` whose instances are store-tagged reactive shells. Safe to call from event handlers, mutation callbacks, or any non-render async code. Subsequent `.update()` / `.delete()` calls on the returned shell auto-publish the row key — existing `.watch()` consumers refire without `useInvalidateKeys` plumbing.

\`\`\`ts
const Task = useModel(TaskModel);
// before: const row = await TaskModel.find(id); await row.update({...}); // silently no-op for reactivity
// after:  const row = await Task.find(id).run();   await row.update({...}); // auto-publishes
\`\`\`

`useAsyncTerminal` and `useWatch` refactored to share the richer `adopt` / `decorate` from a new `adoptInstance` module — both paths now reconcile against the store's identity map (previously `useAsyncTerminal`'s adopt was simpler and didn't soft-register).

### 2. Auto-refetch collection watches on filter-column mutations (commit 2)

Mutations now broadcast `col:<table>:<column>` for each column whose persistent value actually changes. Collection watches walk their `filterBy` / `whereMissing` chain at mount, extract every column name those predicates reference, and subscribe to the matching column keys — refetching when any fires.

Closes the gap where a row update that flipped a filter predicate (e.g. `update({ archivedAt: new Date() })` against a watch with `filterBy({ $null: 'archivedAt' })`) only re-rendered the existing data array without dropping the now-non-matching row, or adding a newly-matching row.

Supported predicate shapes: plain `{ col: value }`, `$null` / `$notNull` keyed by column name, `$in` / `$notIn` / `$between` keyed by column, recursive `$and` / `$or` arrays, and `$not`. Unknown `$`-operators are ignored.

Mutated columns are computed *before* the call runs (since `save()` clears `changedProps` and `update(patch)` needs the pre-mutation `persistentProps` to diff against):
- `update(patch)`: diff `patch` against `persistentProps` so we only broadcast columns whose value actually changes.
- `save()`: read `changedProps` keys — the diff staged by prior `assign(...)` / setters.
- `increment(col)` / `decrement(col)`: the arg names the column.
- `delete` already handles row removal via `store.drop()` + `publishRow`'s `!stillAlive` branch — no column broadcast needed.

### Net effect on consumer code

A real-world consumer can now drop most manual `useInvalidateKeys` plumbing. Every common mutation path — title/description/priority/labels edits on any row, hard-delete, soft-archive that changes a filter column — is fully auto-tracked.

## Tests

14 new tests, full suite 88 → 102:
- `filterColumns.spec.ts` (8) — extractor handles every predicate shape.
- `useModelRun.spec.tsx` (5) — `all` / `first` / `find` terminals, sibling-watch refire on shell mutation/delete.
- `autoInvalidateFilterColumns.spec.tsx` (3) — row drops on filter-flip, hidden row appears on un-archive, non-filter mutations don't refetch.

## Notes

- `package.json` version bumped to `1.1.7-dev.1` during local-tarball consumption from a dependent app; revert to `1.1.6` or roll to `1.1.7` at release time.
- `.gitignore` adds `*.tgz` so `pnpm pack` output stays untracked.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (102/102)
- [x] Dependent app refactored to use new API; manual `invalidate(...)` calls dropped across the brief panel's task-mutation hooks.