### PR TITLE
chore(release): skip empty vNext + prune empty version sections

### DIFF
--- a/.github/scripts/release-roll-history.mjs
+++ b/.github/scripts/release-roll-history.mjs
@@ -3,14 +3,30 @@
 // heading becomes `## v<version>` and a fresh empty `## vNext` block is
 // inserted directly above it. Used only for stable releases (the workflow
 // guards this with the dist-tag).
+//
+// Packages whose `## vNext` section is empty (no entries since the last
+// release) are skipped — they get a version bump in package.json but no
+// new section in HISTORY.md.
 
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const VNEXT_HEADING_LINE = /^## vNext\s*$/m;
+const NEXT_HEADING = /^## /m;
+
+function vNextBody(markdown) {
+  const headingMatch = markdown.match(VNEXT_HEADING_LINE);
+  if (!headingMatch) return null;
+  const startOfBody = headingMatch.index + headingMatch[0].length;
+  const tail = markdown.slice(startOfBody);
+  const nextMatch = tail.match(NEXT_HEADING);
+  const body = nextMatch === null ? tail : tail.slice(0, nextMatch.index);
+  return body.trim();
+}
 
 export function rollHistoryMarkdown(markdown, version) {
-  if (!VNEXT_HEADING_LINE.test(markdown)) return markdown;
+  const body = vNextBody(markdown);
+  if (body === null || body === '') return markdown;
   return markdown.replace(VNEXT_HEADING_LINE, `## vNext\n\n## v${version}\n`);
 }
 

--- a/.github/scripts/release-roll-history.test.mjs
+++ b/.github/scripts/release-roll-history.test.mjs
@@ -32,6 +32,21 @@ test('rollHistoryMarkdown is a no-op when there is no vNext heading', () => {
   strictEqual(rollHistoryMarkdown(before, '1.0.0'), before);
 });
 
+test('rollHistoryMarkdown is a no-op when vNext is empty (no body before next heading)', () => {
+  const before = '# History\n\n## vNext\n\n## v0.4.0\n\n- Older\n';
+  strictEqual(rollHistoryMarkdown(before, '1.0.0'), before);
+});
+
+test('rollHistoryMarkdown is a no-op when vNext is empty (whitespace-only body)', () => {
+  const before = '# History\n\n## vNext\n\n   \n\n## v0.4.0\n\n- Older\n';
+  strictEqual(rollHistoryMarkdown(before, '1.0.0'), before);
+});
+
+test('rollHistoryMarkdown is a no-op when vNext is empty and is the last section', () => {
+  const before = '# History\n\n## vNext\n';
+  strictEqual(rollHistoryMarkdown(before, '1.0.0'), before);
+});
+
 test('rollHistoryMarkdown handles vNext as the last section', () => {
   const before = '# History\n\n## vNext\n\n- Only\n';
   const after = rollHistoryMarkdown(before, '1.0.0');
@@ -44,7 +59,7 @@ test('rollHistoryMarkdown matches vNext heading with trailing whitespace', () =>
   strictEqual(after, '# History\n\n## vNext\n\n## v1.0.0\n\n- Entry\n');
 });
 
-test('rollHistoriesInDir applies the roll to every public package', () => {
+test('rollHistoriesInDir only rolls packages whose vNext has content', () => {
   const root = mkdtempSync(join(tmpdir(), 'next-model-roll-'));
   try {
     mkdirSync(join(root, 'packages', 'core'), { recursive: true });
@@ -61,18 +76,17 @@ test('rollHistoriesInDir applies the roll to every public package', () => {
       join(root, 'packages', 'core', 'HISTORY.md'),
       '# History\n\n## vNext\n\n- core change\n\n## v0.4.0\n\n- old\n',
     );
-    writeFileSync(
-      join(root, 'packages', 'zod', 'HISTORY.md'),
-      '# History\n\n## vNext\n\n## v0.0.1\n\n- old\n',
-    );
+    const zodOriginal = '# History\n\n## vNext\n\n## v0.0.1\n\n- old\n';
+    writeFileSync(join(root, 'packages', 'zod', 'HISTORY.md'), zodOriginal);
 
     const touched = rollHistoriesInDir(root, '1.0.0');
-    strictEqual(touched.length, 2);
+    strictEqual(touched.length, 1);
+    strictEqual(touched[0], '@next-model/core');
 
     const core = readFileSync(join(root, 'packages', 'core', 'HISTORY.md'), 'utf8');
     const zod = readFileSync(join(root, 'packages', 'zod', 'HISTORY.md'), 'utf8');
     strictEqual(core.includes('## vNext\n\n## v1.0.0\n\n- core change'), true);
-    strictEqual(zod.includes('## vNext\n\n## v1.0.0\n\n## v0.0.1'), true);
+    strictEqual(zod, zodOriginal);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/arktype/HISTORY.md
+++ b/packages/arktype/HISTORY.md
@@ -6,20 +6,6 @@
 
 - Bumped dev deps: `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
-## v1.1.2
-
-## v1.1.1
-
-## v1.1.0
-
 ## v1.0.0
 
 - Initial release. `fromArkType(objectType)` returns `{ init, validators, applyColumns, describeColumns }` — same surface as `@next-model/zod` and `@next-model/typebox`, backed by arktype 2.x.

--- a/packages/aurora-data-api-connector/HISTORY.md
+++ b/packages/aurora-data-api-connector/HISTORY.md
@@ -6,24 +6,12 @@
 
 - Bumped deps: `knex` 3.2.9 → 3.2.10, `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
 ## v1.1.2
 
 ### Changed
 
 - `definitionFromOp` defaults `nullable` to `false` (matches the `@next-model/core` builder default, which also flipped in this release). Callers building columns via the alter-table path who relied on the previous nullable-by-default behaviour must now pass `{ null: true }` explicitly.
 - `@next-model/core` moved from `devDependencies` to `peerDependencies` (`^1.1.1`).
-
-## v1.1.1
-
-## v1.1.0
 
 ## v1.0.0
 

--- a/packages/core/HISTORY.md
+++ b/packages/core/HISTORY.md
@@ -10,10 +10,6 @@
 
 - Added a root `pnpm.overrides` entry `ws@>=8.0.0 <8.20.1` → `>=8.20.1` to patch a moderate uninitialized-memory-disclosure advisory (GHSA-58qx-3vcg-4xpx / CVE-2026-45736) reached transitively via `happy-dom` (test-time only). `pnpm audit` is clean across the workspace.
 
-## v1.1.7
-
-## v1.1.6
-
 ## v1.1.5
 
 ### Changed
@@ -69,8 +65,6 @@
 - Mixed-object filter shapes now compose correctly. `filterBy({ workspaceId: 1, $null: 'archivedAt' })` used to silently drop the equality predicate because the connector's `compileFilter` short-circuits on the first `$`-prefixed key it sees. `normalizeFilterShape` now lifts every top-level operator out into its own AND-piece, so equality + `$null` / `$in` / `$gt` / `$and` / `$or` / column-op maps all coexist in a single filter object and survive end-to-end through every connector. Single-operator and pure-equality shapes are unchanged.
 - Nested column-op syntax (`filterBy({ col: { $in: [...] } })`) and the legacy top-level syntax (`filterBy({ $in: { col: [...] } })`) are now explicitly pinned as equivalent — `normalizeFilterShape` already rewrote one to the other, the test surface just makes the contract load-bearing so future refactors can't silently regress.
 - Property getters on Model instances are now installed for every column declared on the schema's `tableDefinition`, not only the keys present in `persistentProps` at construction. Columns omitted at insert (e.g. nullable timestamps like `archivedAt`) are now readable as `instance.col` immediately after `instance.update({ col: value })` — no more `Model.findBy({ id })` re-fetch dance. Legacy Model paths without `defineSchema` still fall back to the previous `persistentProps`-driven loop.
-
-## v1.1.0
 
 ## v1.0.0
 

--- a/packages/express-rest-api/HISTORY.md
+++ b/packages/express-rest-api/HISTORY.md
@@ -6,20 +6,6 @@
 
 - Bumped dev deps: `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
-## v1.1.2
-
-## v1.1.1
-
-## v1.1.0
-
 ## v1.0.0
 
 - `buildOpenApiDocument({ title, version, servers?, resources })` produces a plain-object OpenAPI 3.1 description of the routes a `createRestRouter(...)` exposes — no `swagger-jsdoc` / `openapi3-ts` / `zod-to-openapi` dependency. The generator walks the user-supplied field map (explicit; can be fed by the `zod` / `typebox` / `arktype` bridges' `describeColumns()` output) and emits `<Name>`, `<Name>CreateInput`, `<Name>UpdateInput`, `<Name>FilterInput`, `<Name>List` schemas plus paths for every enabled action, with shared `Error` responses on 400/401/404/422. Pass `actions: [...]` per resource to restrict what ends up in the document. Plug into Express via `app.get('/openapi.json', (_req, res) => res.json(buildOpenApiDocument(...)))`.

--- a/packages/graphql-api/HISTORY.md
+++ b/packages/graphql-api/HISTORY.md
@@ -6,20 +6,6 @@
 
 - Bumped dev deps: `graphql` 16.13.2 → 16.14.0, `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
-## v1.1.2
-
-## v1.1.1
-
-## v1.1.0
-
 ## v1.0.0
 
 - Initial release. `buildModelResource({ Model, name, fields, ... })` returns `{ typeDefs, resolvers }` for six default operations: `list`, `get`, `count`, `create`, `update`, `delete`.

--- a/packages/knex-connector/HISTORY.md
+++ b/packages/knex-connector/HISTORY.md
@@ -6,23 +6,11 @@
 
 - Bumped deps: `knex` 3.2.9 → 3.2.10, `pg` 8.20.0 → 8.21.0, `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
 ## v1.1.2
 
 ### Changed
 
 - `@next-model/core` moved from `devDependencies` to `peerDependencies` (`^1.1.1`). Downstream consumers now install core alongside the connector — fixes the `Cannot find package '@next-model/core'` runtime error when only the connector was added to a project. Monorepo workspaces keep resolving the in-tree core via the existing `devDependencies` entry.
-
-## v1.1.1
-
-## v1.1.0
 
 ## v1.0.0
 

--- a/packages/local-storage-connector/HISTORY.md
+++ b/packages/local-storage-connector/HISTORY.md
@@ -6,12 +6,6 @@
 
 - Bumped dev deps: `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
 ## v1.1.4
 
 ### Changed
@@ -34,8 +28,6 @@
 
 - `connector.ensureSchema()` is inherited from `MemoryConnector` — when the connector carries a schema (`new LocalStorageConnector(opts, { schema })`), the call walks every declared table and initialises an empty array in `localStorage` for each one that doesn't already exist, returning `{ created, existing }`. Existing rows in other tables are untouched. Throws if no schema is attached.
 - Sourcemap files (`dist/**/*.map`) are now published with the package so downstream bundlers resolve stack frames inside `@next-model/local-storage-connector` to the original TypeScript source. No runtime change.
-
-## v1.1.0
 
 ## v1.0.0
 

--- a/packages/mariadb-connector/HISTORY.md
+++ b/packages/mariadb-connector/HISTORY.md
@@ -6,23 +6,11 @@
 
 - Bumped dev deps: `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
 ## v1.1.2
 
 ### Changed
 
 - `@next-model/core` moved from `devDependencies` to `peerDependencies` (`^1.1.1`). Inherits the builder `null` default flip and `orderBy` shape acceptance from `@next-model/mysql-connector` + `@next-model/core`.
-
-## v1.1.1
-
-## v1.1.0
 
 ## v1.0.0
 

--- a/packages/migrations-generator/HISTORY.md
+++ b/packages/migrations-generator/HISTORY.md
@@ -6,20 +6,6 @@
 
 - Bumped dev deps: `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
-## v1.1.2
-
-## v1.1.1
-
-## v1.1.0
-
 ## v1.0.0
 
 - New `schema-from-db` subcommand. Loads a connector module (default export, named `connector` export, or a factory), calls `Connector.reflectSchema()`, and writes a typed-schema TS file with one `defineSchema(...)` per reflected table via `@next-model/core`'s `generateSchemaSource`. Errors out helpfully when the connector doesn't implement `reflectSchema`. Programmatic entry points are exported as `runSchemaFromDb`, `parseSchemaFromDbArgs`, and `runCliAsync`.

--- a/packages/migrations/HISTORY.md
+++ b/packages/migrations/HISTORY.md
@@ -6,20 +6,6 @@
 
 - Bumped dev deps: `knex` 3.2.9 → 3.2.10, `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
-## v1.1.2
-
-## v1.1.1
-
-## v1.1.0
-
 ## v1.0.0
 
 Rolling changelog for the next major release. Items below are appended in the order they ship; this list will be finalized into a version heading when the release is cut.

--- a/packages/mongodb-connector/HISTORY.md
+++ b/packages/mongodb-connector/HISTORY.md
@@ -6,23 +6,11 @@
 
 - Bumped dev deps: `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
 ## v1.1.2
 
 ### Changed
 
 - `@next-model/core` moved from `devDependencies` to `peerDependencies` (`^1.1.1`).
-
-## v1.1.1
-
-## v1.1.0
 
 ## v1.0.0
 

--- a/packages/mysql-connector/HISTORY.md
+++ b/packages/mysql-connector/HISTORY.md
@@ -6,24 +6,12 @@
 
 - Bumped dev deps: `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
 ## v1.1.2
 
 ### Changed
 
 - `definitionFromOp` defaults `nullable` to `false` (matches the `@next-model/core` builder default, which also flipped in this release). Callers relying on the previous nullable-by-default behaviour must now pass `{ null: true }` explicitly.
 - `@next-model/core` moved from `devDependencies` to `peerDependencies` (`^1.1.1`).
-
-## v1.1.1
-
-## v1.1.0
 
 ## v1.0.0
 

--- a/packages/nextjs-api/HISTORY.md
+++ b/packages/nextjs-api/HISTORY.md
@@ -6,20 +6,6 @@
 
 - Bumped dev deps: `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
-## v1.1.2
-
-## v1.1.1
-
-## v1.1.0
-
 ## v1.0.0
 
 - Initial release. `createCollectionHandlers(Model, options)` + `createMemberHandlers(Model, options)` produce Next.js App Router route-handler exports (`{ GET, POST }` / `{ GET, PATCH, DELETE }`) with the same hook surface as `@next-model/express-rest-api`.

--- a/packages/postgres-connector/HISTORY.md
+++ b/packages/postgres-connector/HISTORY.md
@@ -6,24 +6,12 @@
 
 - Bumped deps: `pg` 8.20.0 → 8.21.0, `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
 ## v1.1.2
 
 ### Changed
 
 - `definitionFromOp` defaults `nullable` to `false` (matches the `@next-model/core` builder default, which also flipped in this release). Callers building columns via the alter-table path who relied on the previous nullable-by-default behaviour must now pass `{ null: true }` explicitly.
 - `@next-model/core` moved from `devDependencies` to `peerDependencies` (`^1.1.1`).
-
-## v1.1.1
-
-## v1.1.0
 
 ## v1.0.0
 

--- a/packages/react/HISTORY.md
+++ b/packages/react/HISTORY.md
@@ -39,12 +39,6 @@
 
 - `useAsyncTerminal` and `useWatch` now share `adopt` / `decorate` from a new internal `adoptInstance` module — both paths reconcile against the store's identity map (previously `useAsyncTerminal`'s adopt was simpler and didn't soft-register, which meant instances from `.fetch()` could diverge from the canonical shell in the store).
 
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
 ## v1.1.2
 
 ### Added
@@ -57,8 +51,6 @@
 ### Added
 
 - Sourcemap files (`dist/**/*.map`) are now included in the published tarball so downstream Vite / webpack / Rollup builds resolve stack frames inside `@next-model/react` to the original TypeScript source — no `ENOENT` warnings for `dist/index.js.map`. No runtime change.
-
-## v1.1.0
 
 ## v1.0.0
 

--- a/packages/redis-connector/HISTORY.md
+++ b/packages/redis-connector/HISTORY.md
@@ -10,23 +10,11 @@
 
 - `redis` is kept at `^4.7.1`. node-redis v5 is available but has breaking API changes (client options, command return shapes, connection lifecycle) that require connector rework + retesting against a real Redis server. Tracked for a separate release. `pnpm audit` reports no vulnerabilities in 4.7.1.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
 ## v1.1.2
 
 ### Changed
 
 - `@next-model/core` moved from `devDependencies` to `peerDependencies` (`^1.1.1`).
-
-## v1.1.1
-
-## v1.1.0
 
 ## v1.0.0
 

--- a/packages/sqlite-connector/HISTORY.md
+++ b/packages/sqlite-connector/HISTORY.md
@@ -6,15 +6,11 @@
 
 - Bumped deps: `better-sqlite3` 12.9.0 → 12.10.0, `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
 ## v1.1.6
 
 ### Fixed
 
 - `ensureSchema()` now registers the json / boolean column tracking (and the in-memory `tableDefinitions` entry) for tables that already exist on disk, not just for tables it creates on this boot. Before, the second-and-later boot of any file-backed database left those Maps empty for every pre-existing table, so `hydrateRow` skipped the SQLite `0` / `1` → `false` / `true` coercion and json columns came back as raw TEXT. The leak surfaced loudly at Zod / arktype / validator boundaries downstream with `Expected boolean, received number`; same root cause for json columns coming back unparsed. `createTable` is unchanged — the populate path it already did is now extracted into a private `trackTableDefinition(tableName, def)` helper that `ensureSchema` also calls on the existing-table branch.
-
-## v1.1.5
 
 ## v1.1.4
 
@@ -43,8 +39,6 @@
 ### Changed
 
 - Boolean columns are coerced to `true` / `false` on read when a schema is attached. SQLite has no native boolean and `better-sqlite3` returns 0 / 1 INTEGER for every column declared `boolean`; the connector now mirrors the existing JSON-column behaviour and coerces 0 / 1 → `false` / `true` inside `hydrateRow` for columns the attached schema declares `{ type: 'boolean' }`. `null` and any non-0/1 value passes through unchanged. The write path was already accepting both `true`/`false` and `0`/`1` and is unchanged. **Behaviour change:** callers that compared boolean columns against `0` / `1` strictly (`row.col === 1`) need to switch to `=== true` / `=== false`. Code using `Boolean(row.col)` or loose equality (`== true`) is unaffected. The coercion only activates when a schema is attached at construction; callers using `new SqliteConnector(':memory:')` (no schema) still see raw 0 / 1 INTEGER reads.
-
-## v1.1.0
 
 ## v1.0.0
 

--- a/packages/typebox/HISTORY.md
+++ b/packages/typebox/HISTORY.md
@@ -6,20 +6,6 @@
 
 - Bumped dev deps: `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
-## v1.1.2
-
-## v1.1.1
-
-## v1.1.0
-
 ## v1.0.0
 
 - Initial release. `fromTypeBox(objectSchema)` returns `{ init, validators, applyColumns, describeColumns }` mirroring `@next-model/zod`. `init` applies `Value.Default` + `Value.Check` and throws `ValidationError` with a formatted `Value.Errors` summary.

--- a/packages/valkey-connector/HISTORY.md
+++ b/packages/valkey-connector/HISTORY.md
@@ -10,23 +10,11 @@
 
 - `redis` is kept at `^4.7.1` (Valkey is wire-compatible with Redis and uses `node-redis`). node-redis v5 is deferred pending the underlying `@next-model/redis-connector` migration.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
 ## v1.1.2
 
 ### Changed
 
 - `@next-model/core` moved from `devDependencies` to `peerDependencies` (`^1.1.1`).
-
-## v1.1.1
-
-## v1.1.0
 
 ## v1.0.0
 

--- a/packages/zod/HISTORY.md
+++ b/packages/zod/HISTORY.md
@@ -6,20 +6,6 @@
 
 - Bumped dev deps: `zod` 4.3.6 → 4.4.3, `vitest` / `@vitest/coverage-v8` 4.1.5 → 4.1.6, `@types/node` 25.6.0 → 25.9.0.
 
-## v1.1.7
-
-## v1.1.6
-
-## v1.1.5
-
-## v1.1.4
-
-## v1.1.2
-
-## v1.1.1
-
-## v1.1.0
-
 ## v1.0.0
 
 - Initial release. `fromZod(objectSchema)` returns `{ init, validators, applyColumns, describeColumns }` for use with the Model factory + schema DSL.


### PR DESCRIPTION
## Summary

- `release-roll-history.mjs` now leaves a package's `HISTORY.md` untouched when its `## vNext` body is empty (whitespace-only between the heading and the next `##`). The package still gets its `package.json` version bumped — only the empty-section noise in `HISTORY.md` is suppressed.
- Pruned pre-existing empty `## v<version>` sections across every public package's `HISTORY.md` (-206 lines). Legacy `## v0.?.?` headings with content and `## vNext` are preserved.
- Added 4 new tests covering: empty body, whitespace-only body, vNext-as-last-section, and per-package filtering in `rollHistoriesInDir`.

## Test plan

- [x] `node --test .github/scripts/release-roll-history.test.mjs` — 9/9 pass
- [x] `node --test .github/scripts/release-{compose-notes,bump-versions,derive-dist-tag,roll-history}.test.mjs` — 27/27 pass
- [x] `pnpm lint` — clean
- [x] All `packages/*/HISTORY.md` files still end with a trailing newline