### PR TITLE
feat(graphql-api): support graphql-js 17

### DIFF
--- a/packages/graphql-api/HISTORY.md
+++ b/packages/graphql-api/HISTORY.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Added support for **graphql-js 17**: widened the `graphql` peer range to `^16.9.0 || ^17.0.0` and now build/test against 17. Non-breaking for existing graphql 16 consumers (`@graphql-tools/schema` ^10 already spans both majors).
 - Bumped dev deps: `vitest` / `@vitest/coverage-v8` 4.1.6 → 4.1.9, `@types/node` 25.9.0 → 25.9.3.
 
 ### Security

--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -38,14 +38,14 @@
   "peerDependencies": {
     "@graphql-tools/schema": "^10.0.0",
     "@next-model/core": "workspace:*",
-    "graphql": "^16.9.0"
+    "graphql": "^16.9.0 || ^17.0.0"
   },
   "devDependencies": {
     "@graphql-tools/schema": "^10.0.33",
     "@next-model/core": "workspace:*",
     "@types/node": "^25.9.3",
     "@vitest/coverage-v8": "^4.1.9",
-    "graphql": "^16.14.0",
+    "graphql": "^17.0.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,7 +522,7 @@ importers:
     devDependencies:
       '@graphql-tools/schema':
         specifier: ^10.0.33
-        version: 10.0.33(graphql@16.14.0)
+        version: 10.0.33(graphql@17.0.0)
       '@next-model/core':
         specifier: workspace:*
         version: link:../core
@@ -533,8 +533,8 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
       graphql:
-        specifier: ^16.14.0
-        version: 16.14.0
+        specifier: ^17.0.0
+        version: 17.0.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1921,6 +1921,10 @@ packages:
     resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  graphql@17.0.0:
+    resolution: {integrity: sha512-RSEgqrRNqHVGa46w2pmL9uTFkYPJiJbD5kksOvOaPLrKvBIidX/ttQVlWsR3+Ee8l+mNroC6darpcPIZeElbNg==}
+    engines: {node: ^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0}
+
   happy-dom@20.10.4:
     resolution: {integrity: sha512-bKrsQnFNpcjZG0UPsH7UMN7Oyp3AB42LXk2GuiQmu7l4QFxH7lsw5T1eWEtE2+vbIFrTC45sbNSB2pkB8MTfKA==}
     engines: {node: '>=20.0.0'}
@@ -2900,11 +2904,24 @@ snapshots:
       graphql: 16.14.0
       tslib: 2.8.1
 
+  '@graphql-tools/merge@9.1.9(graphql@17.0.0)':
+    dependencies:
+      '@graphql-tools/utils': 11.1.0(graphql@17.0.0)
+      graphql: 17.0.0
+      tslib: 2.8.1
+
   '@graphql-tools/schema@10.0.33(graphql@16.14.0)':
     dependencies:
       '@graphql-tools/merge': 9.1.9(graphql@16.14.0)
       '@graphql-tools/utils': 11.1.0(graphql@16.14.0)
       graphql: 16.14.0
+      tslib: 2.8.1
+
+  '@graphql-tools/schema@10.0.33(graphql@17.0.0)':
+    dependencies:
+      '@graphql-tools/merge': 9.1.9(graphql@17.0.0)
+      '@graphql-tools/utils': 11.1.0(graphql@17.0.0)
+      graphql: 17.0.0
       tslib: 2.8.1
 
   '@graphql-tools/utils@11.1.0(graphql@16.14.0)':
@@ -2915,9 +2932,21 @@ snapshots:
       graphql: 16.14.0
       tslib: 2.8.1
 
+  '@graphql-tools/utils@11.1.0(graphql@17.0.0)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@17.0.0)
+      '@whatwg-node/promise-helpers': 1.3.2
+      cross-inspect: 1.0.1
+      graphql: 17.0.0
+      tslib: 2.8.1
+
   '@graphql-typed-document-node/core@3.2.0(graphql@16.14.0)':
     dependencies:
       graphql: 16.14.0
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@17.0.0)':
+    dependencies:
+      graphql: 17.0.0
 
   '@img/colour@1.1.0':
     optional: true
@@ -3692,6 +3721,8 @@ snapshots:
       graphql: 16.14.0
 
   graphql@16.14.0: {}
+
+  graphql@17.0.0: {}
 
   happy-dom@20.10.4:
     dependencies:


### PR DESCRIPTION
Stacked on #188 (branched from `tm/dependabot-alerts`); rebase/retarget to `main` once #188 merges.

## Summary

Adds **graphql-js 17** support to `@next-model/graphql-api` — the held-back major from #188, done non-breakingly.

- Peer range widened: `graphql: ^16.9.0` → `^16.9.0 || ^17.0.0`. Existing graphql 16 consumers are unaffected; 17 is now allowed.
- Dev/test dependency bumped to `graphql@^17.0.0` so the package is actually built and tested against 17.
- **No source changes needed**: graphql-api only touches `GraphQLError` (already on the modern `(message, { extensions })` constructor that 17 requires) and the `GraphQLResolveInfo` type. `@graphql-tools/schema@^10` already spans `^14 || ^15 || ^16 || ^17`.

## Why the demo stays on graphql 16

The `graphql-api` demo depends on `graphql-http@1.22.4`, whose peer is `graphql: >=0.11 <=16` — no 17-compatible release yet. The library supporting **both** majors is precisely what lets the demo keep 16 while the package is verified on 17 (pnpm holds both versions side by side).

## Verification

build · typecheck (packages **+ demos**, incl. the graphql-16 demo resolving the 17-built package) · graphql-api tests (19) · lint · `pnpm audit` clean · frozen-lockfile consistent.