### PR TITLE
feat(redis/valkey-connector): upgrade node-redis 4 → 6

### DIFF
--- a/demos/node/server/redis/demo.ts
+++ b/demos/node/server/redis/demo.ts
@@ -31,15 +31,15 @@ class Note extends Model({
 }) {}
 
 // Wipe the prefix so the demo is idempotent.
-let cursor = 0;
+let cursor = '0';
 do {
   const { cursor: next, keys } = await connector.client.scan(cursor, {
     MATCH: 'nm-demo:*',
     COUNT: 100,
   });
-  cursor = Number(next);
+  cursor = String(next);
   if (keys.length > 0) await connector.client.del(keys);
-} while (cursor !== 0);
+} while (cursor !== '0');
 
 await connector.createTable('notes', (t) => {
   t.integer('id', { primary: true, autoIncrement: true, null: false });

--- a/demos/node/server/redis/package.json
+++ b/demos/node/server/redis/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@next-model/core": "workspace:*",
     "@next-model/redis-connector": "workspace:*",
-    "redis": "^4.7.1"
+    "redis": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.3",

--- a/demos/node/server/valkey/demo.ts
+++ b/demos/node/server/valkey/demo.ts
@@ -29,12 +29,12 @@ class Cat extends Model({
   timestamps: false,
 }) {}
 
-let cursor = 0;
+let cursor = '0';
 do {
   const result = await connector.client.scan(cursor, { MATCH: 'nm-vk-demo:*', COUNT: 100 });
-  cursor = Number(result.cursor);
+  cursor = String(result.cursor);
   if (result.keys.length > 0) await connector.client.del(result.keys);
-} while (cursor !== 0);
+} while (cursor !== '0');
 
 await connector.createTable('cats', (t) => {
   t.integer('id', { primary: true, autoIncrement: true, null: false });

--- a/demos/node/server/valkey/package.json
+++ b/demos/node/server/valkey/package.json
@@ -14,7 +14,7 @@
     "@next-model/core": "workspace:*",
     "@next-model/redis-connector": "workspace:*",
     "@next-model/valkey-connector": "workspace:*",
-    "redis": "^4.7.1"
+    "redis": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.3",

--- a/packages/redis-connector/HISTORY.md
+++ b/packages/redis-connector/HISTORY.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Upgraded the bundled `redis` (node-redis) client **4 → 6**. The client is pinned to `RESP: 2`, so every command's return type is identical to before; SCAN now uses string cursors internally (node-redis v6 removed numeric-cursor coercion). Typical usage is unaffected. Callers who pass their own pre-built client via `config.redis` should supply a node-redis v6 client; opt into RESP3 with `config.client.RESP`.
 - Bumped dev deps: `vitest` / `@vitest/coverage-v8` 4.1.6 → 4.1.9, `@types/node` 25.9.0 → 25.9.3.
 
 ### Security

--- a/packages/redis-connector/package.json
+++ b/packages/redis-connector/package.json
@@ -36,7 +36,7 @@
     "prepack": "pnpm build"
   },
   "dependencies": {
-    "redis": "^4.7.1"
+    "redis": "^6.0.0"
   },
   "peerDependencies": {
     "@next-model/core": "^1.1.1"

--- a/packages/redis-connector/src/RedisConnector.ts
+++ b/packages/redis-connector/src/RedisConnector.ts
@@ -99,7 +99,11 @@ export class RedisConnector<S extends DatabaseSchema<any> | undefined = undefine
       this.client = config.redis;
       this.ownsClient = false;
     } else {
-      this.client = createClient(config.client) as RedisClientType;
+      // node-redis v6 defaults to RESP3, which changes the JS return types of
+      // some commands (e.g. hGetAll returns a Map under RESP3). Pin RESP2 to
+      // preserve the v4/v5 wire behaviour this connector's encode/decode and
+      // hash handling assume. Callers can opt into RESP3 via `config.client.RESP`.
+      this.client = createClient({ RESP: 2, ...config.client }) as RedisClientType;
       this.ownsClient = true;
     }
     this.prefix = config.prefix ?? 'nm:';
@@ -499,15 +503,15 @@ export class RedisConnector<S extends DatabaseSchema<any> | undefined = undefine
 
   async dropTable(tableName: string): Promise<void> {
     await this.ensureConnected();
-    let cursor = 0;
+    let cursor = '0';
     do {
       const result = await this.client.scan(cursor, {
         MATCH: this.tablePattern(tableName),
         COUNT: 100,
       });
-      cursor = Number(result.cursor);
+      cursor = String(result.cursor);
       if (result.keys.length > 0) await this.client.del(result.keys);
-    } while (cursor !== 0);
+    } while (cursor !== '0');
   }
 
   async alterTable(spec: AlterTableSpec): Promise<void> {
@@ -542,29 +546,29 @@ export class RedisConnector<S extends DatabaseSchema<any> | undefined = undefine
 
   private async removeFieldFromAllRows(tableName: string, field: string): Promise<void> {
     await this.ensureConnected();
-    let cursor = 0;
+    let cursor = '0';
     do {
       const result = await this.client.scan(cursor, {
         MATCH: this.tablePattern(tableName),
         COUNT: 100,
       });
-      cursor = Number(result.cursor);
+      cursor = String(result.cursor);
       for (const key of result.keys) {
         if (key.endsWith(':meta') || key.endsWith(':nextId') || key.endsWith(':ids')) continue;
         await this.client.hDel(key, field);
       }
-    } while (cursor !== 0);
+    } while (cursor !== '0');
   }
 
   private async renameFieldInAllRows(tableName: string, from: string, to: string): Promise<void> {
     await this.ensureConnected();
-    let cursor = 0;
+    let cursor = '0';
     do {
       const result = await this.client.scan(cursor, {
         MATCH: this.tablePattern(tableName),
         COUNT: 100,
       });
-      cursor = Number(result.cursor);
+      cursor = String(result.cursor);
       for (const key of result.keys) {
         if (key.endsWith(':meta') || key.endsWith(':nextId') || key.endsWith(':ids')) continue;
         const value = await this.client.hGet(key, from);
@@ -572,23 +576,23 @@ export class RedisConnector<S extends DatabaseSchema<any> | undefined = undefine
         await this.client.hSet(key, to, value);
         await this.client.hDel(key, from);
       }
-    } while (cursor !== 0);
+    } while (cursor !== '0');
   }
 
   private async listTables(): Promise<string[]> {
-    let cursor = 0;
+    let cursor = '0';
     const tables = new Set<string>();
     do {
       const result = await this.client.scan(cursor, {
         MATCH: `${this.prefix}*:meta`,
         COUNT: 100,
       });
-      cursor = Number(result.cursor);
+      cursor = String(result.cursor);
       for (const key of result.keys) {
         const name = key.slice(this.prefix.length, -':meta'.length);
         tables.add(name);
       }
-    } while (cursor !== 0);
+    } while (cursor !== '0');
     return [...tables];
   }
 

--- a/packages/redis-connector/src/__tests__/RedisConnector.spec.ts
+++ b/packages/redis-connector/src/__tests__/RedisConnector.spec.ts
@@ -15,12 +15,12 @@ afterAll(() => connector.destroy());
 
 beforeEach(async () => {
   // Wipe every key under our test prefix so each test gets a clean slate.
-  let cursor = 0;
+  let cursor = '0';
   do {
     const result = await connector.client.scan(cursor, { MATCH: 'nm-test:*', COUNT: 100 });
-    cursor = Number(result.cursor);
+    cursor = String(result.cursor);
     if (result.keys.length > 0) await connector.client.del(result.keys);
-  } while (cursor !== 0);
+  } while (cursor !== '0');
 });
 
 describe('RedisConnector', () => {

--- a/packages/valkey-connector/HISTORY.md
+++ b/packages/valkey-connector/HISTORY.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Upgraded the bundled `redis` (node-redis) client **4 → 6**, inherited from `@next-model/redis-connector` (same `RESP: 2` pin and string-cursor SCAN — return types unchanged). Callers who pass their own client via `config.redis` should supply a node-redis v6 client.
 - Bumped dev deps: `vitest` / `@vitest/coverage-v8` 4.1.6 → 4.1.9, `@types/node` 25.9.0 → 25.9.3.
 
 ### Security

--- a/packages/valkey-connector/package.json
+++ b/packages/valkey-connector/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@next-model/redis-connector": "workspace:*",
-    "redis": "^4.7.1"
+    "redis": "^6.0.0"
   },
   "peerDependencies": {
     "@next-model/core": "^1.1.1"

--- a/packages/valkey-connector/src/__tests__/ValkeyConnector.spec.ts
+++ b/packages/valkey-connector/src/__tests__/ValkeyConnector.spec.ts
@@ -17,15 +17,15 @@ beforeAll(() => connector.connect());
 afterAll(() => connector.destroy());
 
 beforeEach(async () => {
-  let cursor = 0;
+  let cursor = '0';
   do {
     const result = await connector.client.scan(cursor, {
       MATCH: 'nm-vk-test:*',
       COUNT: 100,
     });
-    cursor = Number(result.cursor);
+    cursor = String(result.cursor);
     if (result.keys.length > 0) await connector.client.del(result.keys);
-  } while (cursor !== 0);
+  } while (cursor !== '0');
 });
 
 describe('ValkeyConnector', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,8 +326,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/redis-connector
       redis:
-        specifier: ^4.7.1
-        version: 4.7.1
+        specifier: ^6.0.0
+        version: 6.0.0
     devDependencies:
       '@types/node':
         specifier: ^25.9.3
@@ -370,8 +370,8 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/valkey-connector
       redis:
-        specifier: ^4.7.1
-        version: 4.7.1
+        specifier: ^6.0.0
+        version: 6.0.0
     devDependencies:
       '@types/node':
         specifier: ^25.9.3
@@ -796,8 +796,8 @@ importers:
   packages/redis-connector:
     dependencies:
       redis:
-        specifier: ^4.7.1
-        version: 4.7.1
+        specifier: ^6.0.0
+        version: 6.0.0
     devDependencies:
       '@next-model/core':
         specifier: workspace:*
@@ -867,8 +867,8 @@ importers:
         specifier: workspace:*
         version: link:../redis-connector
       redis:
-        specifier: ^4.7.1
-        version: 4.7.1
+        specifier: ^6.0.0
+        version: 6.0.0
     devDependencies:
       '@next-model/core':
         specifier: workspace:*
@@ -1257,34 +1257,41 @@ packages:
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
-  '@redis/bloom@1.2.0':
-    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+  '@redis/bloom@6.0.0':
+    resolution: {integrity: sha512-P0n5NkV9IIdT6nYXOfMHG83sho8pE7Nay7yw27wOGVLv4DthgvzebpGz6m7VuMTizeJmw3LPw2Xek5wFUhGpVw==}
+    engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@redis/client': ^1.0.0
+      '@redis/client': ^6.0.0
 
-  '@redis/client@1.6.1':
-    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
-    engines: {node: '>=14'}
-
-  '@redis/graph@1.1.1':
-    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+  '@redis/client@6.0.0':
+    resolution: {integrity: sha512-NS4iIT25r24sAjNQ2nSRdCW5jPJoV0rxkBee27oTeR+RXaOu89cjIsrww5rPBaYVGVdL1QCx9uz9141gZiSKdQ==}
+    engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@redis/client': ^1.0.0
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
 
-  '@redis/json@1.0.7':
-    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+  '@redis/json@6.0.0':
+    resolution: {integrity: sha512-F+eqFfgPcy57Zs1KW7UtLnBtRk6lxAUIoe7dyZerpm6e+ssYXG/dWJrbrHFYs0b7tt6QBtYpVuukBuM9XqhUAg==}
+    engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@redis/client': ^1.0.0
+      '@redis/client': ^6.0.0
 
-  '@redis/search@1.2.0':
-    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+  '@redis/search@6.0.0':
+    resolution: {integrity: sha512-VHuCJ2W0YWFixGZh/l//8JiyOsD4gN+NhjdRAGIoUe0UQ4mtq1NyY2ZJ973XT+vYhaU21XdK8r8oNrd5n7wbzQ==}
+    engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@redis/client': ^1.0.0
+      '@redis/client': ^6.0.0
 
-  '@redis/time-series@1.1.0':
-    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+  '@redis/time-series@6.0.0':
+    resolution: {integrity: sha512-QWhkYsg+3lhBrBf+cbzybtV8LQcSrk7iXIgTaGU+pHNFTkql7TpVRE24ROS6M2ybVIV6O/zxTqfxgxxYiqyw0Q==}
+    engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@redis/client': ^1.0.0
+      '@redis/client': ^6.0.0
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -1882,10 +1889,6 @@ packages:
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
 
-  generic-pool@3.9.0:
-    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
-    engines: {node: '>= 4'}
-
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -2442,8 +2445,9 @@ packages:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
 
-  redis@4.7.1:
-    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
+  redis@6.0.0:
+    resolution: {integrity: sha512-n9Thfc39OXleEoPT2k5gwKsqY+HfCww3YS71ofcr9KKbkn89bpjU9dToIlD+JRdM3/GYQkwMtVgTxLyed+LptQ==}
+    engines: {node: '>= 20.0.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -2795,9 +2799,6 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
@@ -3074,31 +3075,25 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
-  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
+  '@redis/bloom@6.0.0(@redis/client@6.0.0)':
     dependencies:
-      '@redis/client': 1.6.1
+      '@redis/client': 6.0.0
 
-  '@redis/client@1.6.1':
+  '@redis/client@6.0.0':
     dependencies:
       cluster-key-slot: 1.1.2
-      generic-pool: 3.9.0
-      yallist: 4.0.0
 
-  '@redis/graph@1.1.1(@redis/client@1.6.1)':
+  '@redis/json@6.0.0(@redis/client@6.0.0)':
     dependencies:
-      '@redis/client': 1.6.1
+      '@redis/client': 6.0.0
 
-  '@redis/json@1.0.7(@redis/client@1.6.1)':
+  '@redis/search@6.0.0(@redis/client@6.0.0)':
     dependencies:
-      '@redis/client': 1.6.1
+      '@redis/client': 6.0.0
 
-  '@redis/search@1.2.0(@redis/client@1.6.1)':
+  '@redis/time-series@6.0.0(@redis/client@6.0.0)':
     dependencies:
-      '@redis/client': 1.6.1
-
-  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
+      '@redis/client': 6.0.0
 
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
@@ -3656,8 +3651,6 @@ snapshots:
     dependencies:
       is-property: 1.0.2
 
-  generic-pool@3.9.0: {}
-
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -4144,14 +4137,16 @@ snapshots:
     dependencies:
       resolve: 1.22.12
 
-  redis@4.7.1:
+  redis@6.0.0:
     dependencies:
-      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
-      '@redis/client': 1.6.1
-      '@redis/graph': 1.1.1(@redis/client@1.6.1)
-      '@redis/json': 1.0.7(@redis/client@1.6.1)
-      '@redis/search': 1.2.0(@redis/client@1.6.1)
-      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
+      '@redis/bloom': 6.0.0(@redis/client@6.0.0)
+      '@redis/client': 6.0.0
+      '@redis/json': 6.0.0(@redis/client@6.0.0)
+      '@redis/search': 6.0.0(@redis/client@6.0.0)
+      '@redis/time-series': 6.0.0(@redis/client@6.0.0)
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
 
   resolve-from@5.0.0: {}
 
@@ -4505,8 +4500,6 @@ snapshots:
   ws@8.21.0: {}
 
   xtend@4.0.2: {}
-
-  yallist@4.0.0: {}
 
   yallist@5.0.0: {}
 


### PR DESCRIPTION
Stacked on #188 (branched from `tm/dependabot-alerts`); rebase/retarget to `main` once #188 merges.

## Summary

Upgrades the bundled `redis` (node-redis) client from `^4.7.1` to `^6.0.0` in `@next-model/redis-connector` and `@next-model/valkey-connector` — the other held-back major from #188. (`redis` 5 was skipped; 6 is current.)

## Breaking changes handled

1. **RESP3 is the default in v6** (was RESP2), changing the JS return types of some commands (e.g. `hGetAll`). Per the [official v5→v6 migration guide](https://github.com/redis/node-redis/blob/master/docs/v5-to-v6.md), the client is pinned to `RESP: 2` in `createClient`, preserving the exact return types the connector's encode/decode + hash handling rely on. Callers can opt into RESP3 via `config.client.RESP`.
2. **v6's RESP encoder no longer coerces numeric args to strings.** `SCAN` cursors are now strings (`'0'` / `String(result.cursor)`) in the connector, its tests' cleanup loops, and the redis/valkey demos. (This was the only runtime break — caught by a live-redis test run.)

## Consumer impact

Public connector API unchanged. Typical usage (passing `config.client` options, letting the connector build the client) is unaffected. Consumers who pass a **pre-built** client via `config.redis` should now supply a node-redis **v6** client.

## Verification

build · typecheck (packages **+ demos**) · lint · `pnpm audit` clean · frozen-lockfile · **full redis-connector (82) and valkey-connector (71) suites run against a live redis** (not just CI). Demos bumped to `redis@^6`; only redis 6 remains in the tree.